### PR TITLE
Allow arbitrary INTFLASH_ADDRESS

### DIFF
--- a/Core/Src/system_stm32h7xx.c
+++ b/Core/Src/system_stm32h7xx.c
@@ -59,9 +59,21 @@
   #define HSI_VALUE    ((uint32_t)64000000) /*!< Value of the Internal oscillator in Hz*/
 #endif /* HSI_VALUE */
 
+
 #if !defined  (INTFLASH_BANK)
   #define INTFLASH_BANK 1
 #endif /* INTFLASH_BANK */
+
+
+#if !defined  (INTFLASH_ADDRESS)
+  #if INTFLASH_BANK == 1
+    #define INTFLASH_ADDRESS 0x08000000
+  #elif INTFLASH_BANK == 2
+    #define INTFLASH_ADDRESS 0x08100000
+  #else
+    #error INTFLASH_BANK must be either 1 (default) or 2
+  #endif /* INTFLASH_ADDRESS */
+#endif /* INTFLASH_ADDRESS */
 
 /**
   * @}
@@ -267,15 +279,7 @@ void SystemInit (void)
 #ifdef VECT_TAB_SRAM
   SCB->VTOR = D1_AXISRAM_BASE  | VECT_TAB_OFFSET; /* Vector Table Relocation in Internal AXI-RAM */
 #else
-
-#if INTFLASH_BANK == 1
-  SCB->VTOR = FLASH_BANK1_BASE | VECT_TAB_OFFSET; /* Vector Table Relocation in Internal FLASH */
-#elif INTFLASH_BANK == 2
-  SCB->VTOR = FLASH_BANK2_BASE | VECT_TAB_OFFSET; /* Vector Table Relocation in Internal FLASH */
-#else
-#error INTFLASH_BANK must be either 1 (default) or 2
-#endif
-
+  SCB->VTOR = INTFLASH_ADDRESS | VECT_TAB_OFFSET; /* Vector Table Relocation in Internal FLASH */
 #endif
 
 #endif /*DUAL_CORE && CORE_CM4*/

--- a/Makefile.common
+++ b/Makefile.common
@@ -782,9 +782,6 @@ flash_test: flash_intflash
 # Programs both the external and internal flash.
 flash: CheckTools CheckDirtySubmodules
 	$(V)$(MAKE) flash_intflash
-ifeq ($(INTFLASH_BANK), 1)
-	$(V)$(MAKE) flash_intflash2
-endif
 	$(V)$(MAKE) flash_extflash
 	$(V)$(RESET_DBGMCU_CMD)
 .PHONY: flash

--- a/Makefile.common
+++ b/Makefile.common
@@ -723,7 +723,7 @@ start_bank_2:
 		-c 'resume;exit'
 .PHONY: start_bank_2
 
-start_bank:  # Start code located at INTFLASH_ADDRESS
+start:  # Start code located at INTFLASH_ADDRESS
 	$(OPENOCD) -f scripts/interface_$(ADAPTER).cfg \
 		-c 'init; reset halt' \
 		-c 'set MSP 0x[string range [mdw $(INTFLASH_ADDRESS)] 12 19]' \
@@ -733,7 +733,7 @@ start_bank:  # Start code located at INTFLASH_ADDRESS
 		-c 'reg msp $$MSP' \
 		-c 'reg pc $$PC' \
 		-c 'resume;exit'
-.PHONY: start_bank
+.PHONY: start
 
 
 # Programs the internal flash using a new OpenOCD instance
@@ -745,15 +745,6 @@ flash_intflash: $(BUILD_DIR)/$(TARGET)_intflash.bin
 flash_intflash_nc: $(BUILD_DIR)/$(TARGET)_intflash.bin
 	echo "program $< $(INTFLASH_ADDRESS) verify reset" | nc -c localhost 4444
 .PHONY: flash_intflash_nc
-
-flash_intflash2: $(BUILD_DIR)/$(TARGET)_intflash2.bin
-#	$(OPENOCD) -f scripts/interface_$(ADAPTER).cfg -c "program $< 0x08100000 verify reset exit"
-.PHONY: flash_intflash2
-
-# Flashes using an existing openocd instance
-flash_intflash2_nc: $(BUILD_DIR)/$(TARGET)_intflash2.bin
-	echo "program $< 0x08100000 verify reset" | nc -c localhost 4444
-.PHONY: flash_intflash2_nc
 
 flash_extflash: $(BUILD_DIR)/$(TARGET)_extflash.bin
 	$(FLASH_MULTI) $(BUILD_DIR)/$(TARGET)_extflash.bin $(EXTFLASH_OFFSET)

--- a/Makefile.common
+++ b/Makefile.common
@@ -214,6 +214,12 @@ endif
 ROMINFOCODE ?= $(SCODEPAGE)
 CODEPAGE_PARAM := --codepage=$(ROMINFOCODE)
 
+
+#######################################
+# MSX
+#######################################
+MSX_USE_BANK_2 ?= 0
+
 #######################################
 # cover flow
 #######################################
@@ -392,6 +398,7 @@ C_DEFS +=  \
 -DINTFLASH_ADDRESS=$(INTFLASH_ADDRESS) \
 -DBIG_BANK=$(BIG_BANK) \
 -DEXTFLASH_SIZE=$(EXTFLASH_SIZE) \
+-DMSX_USE_BANK_2=$(MSX_USE_BANK_2) \
 -DOFF_SAVESTATE=$(OFF_SAVESTATE) \
 -DCODEPAGE=$(CODEPAGE) \
 -DUICODEPAGE=$(UICODEPAGE) \
@@ -878,6 +885,8 @@ help:
 	@echo "  GNW_TARGET          - Game & Watch target, Valid values {mario,zelda} (default=mario)"
 	@echo "  GAME_GENIE          - Set to 1 to enable game genie support (deprecated, use CHEAT_CODES instead)"
 	@echo "  CHEAT_CODES         - Set to 1 to enable cheat codes support (default=0)"
+	@echo "  MSX_USE_BANK_2      - Set to 1 to use Internal Bank 2 for MSX performance improvements."
+	@echo "                        Retro-Go must be in Bank 1."
 	@echo "  SHARED_HIBERNATE_SAVESTATE - Set to 1 to enable a separate savestate for off/on (default=0)"
 	@echo "  DISABLE_SPLASH_SCREEN - Set to 1 to disable the slash screen animation at startup (default=0)"
 	@echo "  FORCE_NOFRENDO      - Set to 1 to force use of previous nofrendo-go emulator instead of fceumm (default=0)"
@@ -896,6 +905,7 @@ help:
 	@echo "  ENABLE_SCREENSHOT=$(ENABLE_SCREENSHOT)"
 	@echo "  GNW_TARGET=$(GNW_TARGET)"
 	@echo "  CHEAT_CODES=$(CHEAT_CODES)"
+	@echo "  MSX_USE_BANK_2=$(MSX_USE_BANK_2)"
 	@echo "  GCC_PATH=$(GCC_PATH)"
 	@echo "  PREFIX=$(PREFIX)"
 	@echo "  CODEPAGE=$(CODEPAGE)"

--- a/Makefile.common
+++ b/Makefile.common
@@ -61,9 +61,33 @@ else
 	endif
 endif
 
+# Configure INTFLASH_BANK and INTFLASH_ADDRESS
+INTFLASH_ADDRESS ?= 0x08000000
+INTFLASH_ADDRESS_DECIMAL = $(shell printf "%d" $(INTFLASH_ADDRESS))
+ifdef INTFLASH_BANK
+  # Sanity check that INTFLASH_ADDRESS and INTFLASH_BANK agree
+  ifeq ($(shell [ $(INTFLASH_ADDRESS_DECIMAL) -ge 134217728 -a $(INTFLASH_ADDRESS_DECIMAL) -lt 135266304 ] && echo true),true)
+	# INTFLASH_ADDRESS is in range [0x08000000, 0x08100000)
+    ifneq ($(INTFLASH_BANK),1)
+	  $(error Inconsistent INTFLASH_BANK and INTFLASH_ADDRESS)
+    endif
+  else
+    ifneq ($(INTFLASH_BANK),2)
+	  $(error Inconsistent INTFLASH_BANK and INTFLASH_ADDRESS)
+    endif
+  endif
+else
+  # INTFLASH_BANK is not set; attempt to derive flashbank from INTFLASH_ADDRESS
+  ifeq ($(shell [ $(INTFLASH_ADDRESS_DECIMAL) -ge 134217728 -a $(INTFLASH_ADDRESS_DECIMAL) -lt 135266304 ] && echo true),true)
+	# INTFLASH_ADDRESS is in range [0x08000000, 0x08100000)
+	INTFLASH_BANK = 1
+  else
+	INTFLASH_BANK = 2
+  endif
+endif
+
 # Configure external flash size in MB (Megabytes)
 EXTFLASH_SIZE_MB ?= 1
-INTFLASH_BANK ?= 1
 BIG_BANK ?= 1
 
 EXTFLASH_SIZE ?= $(shell echo "$$(( $(EXTFLASH_SIZE_MB) * 1024 * 1024 ))")
@@ -456,12 +480,6 @@ CFLAGS += -MMD -MP -MF"$(@:%.o=%.d)"
 LDFLAGS += -Wl,--defsym=__EXTFLASH_OFFSET__=$(EXTFLASH_OFFSET)
 LDFLAGS += -Wl,--defsym=__EXTFLASH_TOTAL_LENGTH__=$(EXTFLASH_SIZE)
 LDFLAGS += -Wl,--defsym=ENABLE_SCREENSHOT=$(ENABLE_SCREENSHOT)
-
-ifeq ($(INTFLASH_BANK), 1)
-	INTFLASH_ADDRESS ?= 0x08000000
-else ifeq ($(INTFLASH_BANK), 2)
-	INTFLASH_ADDRESS ?= 0x08100000
-endif
 
 LDFLAGS += -Wl,--defsym=__INTFLASH__=$(INTFLASH_ADDRESS)
 

--- a/Makefile.common
+++ b/Makefile.common
@@ -365,6 +365,7 @@ AS_DEFS +=
 C_DEFS +=  \
 -D_GNU_SOURCE \
 -DINTFLASH_BANK=$(INTFLASH_BANK) \
+-DINTFLASH_ADDRESS=$(INTFLASH_ADDRESS) \
 -DBIG_BANK=$(BIG_BANK) \
 -DEXTFLASH_SIZE=$(EXTFLASH_SIZE) \
 -DOFF_SAVESTATE=$(OFF_SAVESTATE) \
@@ -457,9 +458,9 @@ LDFLAGS += -Wl,--defsym=__EXTFLASH_TOTAL_LENGTH__=$(EXTFLASH_SIZE)
 LDFLAGS += -Wl,--defsym=ENABLE_SCREENSHOT=$(ENABLE_SCREENSHOT)
 
 ifeq ($(INTFLASH_BANK), 1)
-	INTFLASH_ADDRESS = 0x08000000
+	INTFLASH_ADDRESS ?= 0x08000000
 else ifeq ($(INTFLASH_BANK), 2)
-	INTFLASH_ADDRESS = 0x08100000
+	INTFLASH_ADDRESS ?= 0x08100000
 endif
 
 LDFLAGS += -Wl,--defsym=__INTFLASH__=$(INTFLASH_ADDRESS)
@@ -688,11 +689,11 @@ reset:
 
 erase_intflash_1:
 	$(OPENOCD) -f scripts/interface_$(ADAPTER).cfg -c "init; halt; flash erase_address 0x08000000 131072; resume; exit"
-.PHONY: erase_intflash1
+.PHONY: erase_intflash_1
 
 erase_intflash_2:
 	$(OPENOCD) -f scripts/interface_$(ADAPTER).cfg -c "init; halt; flash erase_address 0x08100000 131072; resume; exit"
-.PHONY: erase_intflash2
+.PHONY: erase_intflash_2
 
 erase_extflash: flash_intflash
 	$(V)./scripts/extflash_erase.sh $(EXTFLASH_SIZE)
@@ -721,6 +722,19 @@ start_bank_2:
 		-c 'reg pc $$PC' \
 		-c 'resume;exit'
 .PHONY: start_bank_2
+
+start_bank:  # Start code located at INTFLASH_ADDRESS
+	$(OPENOCD) -f scripts/interface_$(ADAPTER).cfg \
+		-c 'init; reset halt' \
+		-c 'set MSP 0x[string range [mdw $(INTFLASH_ADDRESS)] 12 19]' \
+		-c 'set PC 0x[string range [mdw [format 0x%x [expr {$(INTFLASH_ADDRESS) + 0x4}]]] 12 19]' \
+		-c 'echo "Setting MSP -> $$MSP"' \
+		-c 'echo "Setting PC -> $$PC"' \
+		-c 'reg msp $$MSP' \
+		-c 'reg pc $$PC' \
+		-c 'resume;exit'
+.PHONY: start_bank
+
 
 # Programs the internal flash using a new OpenOCD instance
 flash_intflash: $(BUILD_DIR)/$(TARGET)_intflash.bin
@@ -832,6 +846,7 @@ help:
 	@echo "  LARGE_FLASH         - Sets the external flash size to 16MB  (deprecated)"
 	@echo "  EXTFLASH_OFFSET     - Places the data at an offset in the external flash (useful for dual boot)"
 	@echo "  INTFLASH_BANK       - Sets the internal flash bank. Valid values {1,2} (default=1)."
+	@echo "  INTFLASH_ADDRESS    - Explicit internal flash address. If not provided, derived from INTFLASH_BANK.
 	@echo "  BIG_BANK            - Use internal flash bank as undocumented 256k.(default=1, set 0 to 128k)."
 	@echo "                        It's required patched OPENOCD to work"
 	@echo "  COMPRESS            - Configures ROM compression, Valid values {0,lzma} (default=lzma)."

--- a/scripts/flashapp.sh
+++ b/scripts/flashapp.sh
@@ -40,10 +40,12 @@ VAR_program_chunk_count=$(     printf '0x%08x\n' $(get_symbol "program_chunk_cou
 VAR_program_expected_sha256=$( printf '0x%08x\n' $(get_symbol "program_expected_sha256"))
 
 INTFLASH_BANK=${INTFLASH_BANK:-1}
-if [ $INTFLASH_BANK -eq 2 ]; then
-    INTFLASH_ADDRESS=0x08100000
-else
-    INTFLASH_ADDRESS=0x08000000
+if [ -z "$INTFLASH_ADDRESS" ]; then
+    if [ $INTFLASH_BANK -eq 2 ]; then
+        INTFLASH_ADDRESS=0x08100000
+    else
+        INTFLASH_ADDRESS=0x08000000
+    fi
 fi
 
 # $1: file to hash


### PR DESCRIPTION
This will allow for for retro-go to be installed to an arbitrary internal flash location. For example:

1. Bank 1 [0x0800_0000] patched stock.
2. Bank 1 [0x0802_0000] retro-go
3. Bank 2 [0x0810_0000] Zelda3

Will link relevant game-and-watch-patch PR soon.