### PR TITLE
Fixed 'in-game overlay' not showing in most scaling/filtering modes

### DIFF
--- a/Core/Src/porting/gb/main_gb.c
+++ b/Core/Src/porting/gb/main_gb.c
@@ -105,6 +105,8 @@ static inline void screen_blit_nn(int32_t dest_width, int32_t dest_height)
     printf("Blit: %d us\n", (1000000 * PROFILING_DIFF(t_blit)) / t_blit_t0.SecondFraction);
 #endif
 
+    common_ingame_overlay();
+
     lcd_swap();
 }
 
@@ -168,6 +170,8 @@ static void screen_blit_bilinear(int32_t dest_width)
     printf("Blit: %d us\n", (1000000 * PROFILING_DIFF(t_blit)) / t_blit_t0.SecondFraction);
 #endif
 
+    common_ingame_overlay();
+
     lcd_swap();
 }
 
@@ -227,11 +231,11 @@ static inline void screen_blit_v3to5(void) {
 #ifdef PROFILING_ENABLED
     printf("Blit: %d us\n", (1000000 * PROFILING_DIFF(t_blit)) / t_blit_t0.SecondFraction);
 #endif
+
     common_ingame_overlay();
 
     lcd_swap();
 }
-
 
 static inline void screen_blit_jth(void) {
     static uint32_t lastFPSTime = 0;
@@ -308,9 +312,10 @@ static inline void screen_blit_jth(void) {
     printf("Blit: %d us\n", (1000000 * PROFILING_DIFF(t_blit)) / t_blit_t0.SecondFraction);
 #endif
 
+    common_ingame_overlay();
+
     lcd_swap();
 }
-
 
 static void blit(void)
 {


### PR DESCRIPTION
Fixed 'in-game overlay' not showing in most scaling/filtering modes when running the GB emulator