### PR TITLE
 Better bar graph font tiles

### DIFF
--- a/Core/Inc/retro-go/fonts/font_cp1252_Greybeard.h
+++ b/Core/Inc/retro-go/fonts/font_cp1252_Greybeard.h
@@ -86,31 +86,31 @@ const char font_cp1252_Greybeard[] FONT_DATA = {
      0xf0,0x0f,  // ....OOOOOOOO....
      0x00,0x00,  // ................
      /* 007 */ 
-     0xff, // OOOOOOOO
-     0xff, // OOOOOOOO
-     0xff, // OOOOOOOO
-     0xff, // OOOOOOOO
-     0xff, // OOOOOOOO
-     0xff, // OOOOOOOO
-     0xff, // OOOOOOOO
-     0xff, // OOOOOOOO
-     0xff, // OOOOOOOO
-     0xff, // OOOOOOOO
-     0xff, // OOOOOOOO
-     0xff, // OOOOOOOO
-     /* 008 */ 
-     0xfe, // .OOOOOOO
-     0x82, // .O.....O
-     0x82, // .O.....O
-     0x82, // .O.....O
-     0x82, // .O.....O
-     0x82, // .O.....O
-     0x82, // .O.....O
-     0x82, // .O.....O
-     0x82, // .O.....O
-     0x82, // .O.....O
-     0x82, // .O.....O
-     0xfe, // .OOOOOOO
+     0b00000000, // ........
+     0b01111110, // .OOOOOO.
+     0b01111110, // .OOOOOO.
+     0b01111110, // .OOOOOO.
+     0b01111110, // .OOOOOO.
+     0b01111110, // .OOOOOO.
+     0b01111110, // .OOOOOO.
+     0b01111110, // .OOOOOO.
+     0b01111110, // .OOOOOO.
+     0b01111110, // .OOOOOO.
+     0b01111110, // .OOOOOO.
+     0b00000000, // ........
+     /* 008 */
+     0b00000000, // ........
+     0b01111110, // .OOOOOO.
+     0b01000010, // .O....O.
+     0b01000010, // .O....O.
+     0b01000010, // .O....O.
+     0b01000010, // .O....O.
+     0b01000010, // .O....O.
+     0b01000010, // .O....O.
+     0b01000010, // .O....O.
+     0b01000010, // .O....O.
+     0b01111110, // .OOOOOO.
+     0b00000000, // ........
      /* 009 */ 
      0x00,0x00,  // ............
      0x00,0x00,  // ............

--- a/Core/Inc/retro-go/fonts/font_cp1252_Sans_serif.h
+++ b/Core/Inc/retro-go/fonts/font_cp1252_Sans_serif.h
@@ -86,31 +86,31 @@ const char font_cp1252_Sans_serif[] FONT_DATA = {
      0xf0,0x0f,  // ....OOOOOOOO....
      0x00,0x00,  // ................
      /* 007 */ 
-     0xff, // OOOOOOOO
-     0xff, // OOOOOOOO
-     0xff, // OOOOOOOO
-     0xff, // OOOOOOOO
-     0xff, // OOOOOOOO
-     0xff, // OOOOOOOO
-     0xff, // OOOOOOOO
-     0xff, // OOOOOOOO
-     0xff, // OOOOOOOO
-     0xff, // OOOOOOOO
-     0xff, // OOOOOOOO
-     0xff, // OOOOOOOO
-     /* 008 */ 
-     0xfe, // .OOOOOOO
-     0x82, // .O.....O
-     0x82, // .O.....O
-     0x82, // .O.....O
-     0x82, // .O.....O
-     0x82, // .O.....O
-     0x82, // .O.....O
-     0x82, // .O.....O
-     0x82, // .O.....O
-     0x82, // .O.....O
-     0x82, // .O.....O
-     0xfe, // .OOOOOOO
+     0b00000000, // ........
+     0b01111110, // .OOOOOO.
+     0b01111110, // .OOOOOO.
+     0b01111110, // .OOOOOO.
+     0b01111110, // .OOOOOO.
+     0b01111110, // .OOOOOO.
+     0b01111110, // .OOOOOO.
+     0b01111110, // .OOOOOO.
+     0b01111110, // .OOOOOO.
+     0b01111110, // .OOOOOO.
+     0b01111110, // .OOOOOO.
+     0b00000000, // ........
+     /* 008 */
+     0b00000000, // ........
+     0b01111110, // .OOOOOO.
+     0b01000010, // .O....O.
+     0b01000010, // .O....O.
+     0b01000010, // .O....O.
+     0b01000010, // .O....O.
+     0b01000010, // .O....O.
+     0b01000010, // .O....O.
+     0b01000010, // .O....O.
+     0b01000010, // .O....O.
+     0b01111110, // .OOOOOO.
+     0b00000000, // ........
      /* 009 */ 
      0x00,0x00,  // ............
      0x00,0x00,  // ............

--- a/Core/Inc/retro-go/fonts/font_cp1252_Sans_serif_Bold.h
+++ b/Core/Inc/retro-go/fonts/font_cp1252_Sans_serif_Bold.h
@@ -86,31 +86,31 @@ const char font_cp1252_Sans_serif_Bold[] FONT_DATA = {
      0xf0,0x0f,  // ....OOOOOOOO....
      0x00,0x00,  // ................
      /* 007 */ 
-     0xff, // OOOOOOOO
-     0xff, // OOOOOOOO
-     0xff, // OOOOOOOO
-     0xff, // OOOOOOOO
-     0xff, // OOOOOOOO
-     0xff, // OOOOOOOO
-     0xff, // OOOOOOOO
-     0xff, // OOOOOOOO
-     0xff, // OOOOOOOO
-     0xff, // OOOOOOOO
-     0xff, // OOOOOOOO
-     0xff, // OOOOOOOO
-     /* 008 */ 
-     0xfe, // .OOOOOOO
-     0x82, // .O.....O
-     0x82, // .O.....O
-     0x82, // .O.....O
-     0x82, // .O.....O
-     0x82, // .O.....O
-     0x82, // .O.....O
-     0x82, // .O.....O
-     0x82, // .O.....O
-     0x82, // .O.....O
-     0x82, // .O.....O
-     0xfe, // .OOOOOOO
+     0b00000000, // ........
+     0b01111110, // .OOOOOO.
+     0b01111110, // .OOOOOO.
+     0b01111110, // .OOOOOO.
+     0b01111110, // .OOOOOO.
+     0b01111110, // .OOOOOO.
+     0b01111110, // .OOOOOO.
+     0b01111110, // .OOOOOO.
+     0b01111110, // .OOOOOO.
+     0b01111110, // .OOOOOO.
+     0b01111110, // .OOOOOO.
+     0b00000000, // ........
+     /* 008 */
+     0b00000000, // ........
+     0b01111110, // .OOOOOO.
+     0b01000010, // .O....O.
+     0b01000010, // .O....O.
+     0b01000010, // .O....O.
+     0b01000010, // .O....O.
+     0b01000010, // .O....O.
+     0b01000010, // .O....O.
+     0b01000010, // .O....O.
+     0b01000010, // .O....O.
+     0b01111110, // .OOOOOO.
+     0b00000000, // ........
      /* 009 */ 
      0x00,0x00,  // ............
      0x00,0x00,  // ............

--- a/Core/Inc/retro-go/fonts/font_cp1252_Serif.h
+++ b/Core/Inc/retro-go/fonts/font_cp1252_Serif.h
@@ -86,31 +86,31 @@ const char font_cp1252_Serif[] FONT_DATA = {
      0xf0,0x0f,  // ....OOOOOOOO....
      0x00,0x00,  // ................
      /* 007 */ 
-     0xff, // OOOOOOOO
-     0xff, // OOOOOOOO
-     0xff, // OOOOOOOO
-     0xff, // OOOOOOOO
-     0xff, // OOOOOOOO
-     0xff, // OOOOOOOO
-     0xff, // OOOOOOOO
-     0xff, // OOOOOOOO
-     0xff, // OOOOOOOO
-     0xff, // OOOOOOOO
-     0xff, // OOOOOOOO
-     0xff, // OOOOOOOO
-     /* 008 */ 
-     0xfe, // .OOOOOOO
-     0x82, // .O.....O
-     0x82, // .O.....O
-     0x82, // .O.....O
-     0x82, // .O.....O
-     0x82, // .O.....O
-     0x82, // .O.....O
-     0x82, // .O.....O
-     0x82, // .O.....O
-     0x82, // .O.....O
-     0x82, // .O.....O
-     0xfe, // .OOOOOOO
+     0b00000000, // ........
+     0b01111110, // .OOOOOO.
+     0b01111110, // .OOOOOO.
+     0b01111110, // .OOOOOO.
+     0b01111110, // .OOOOOO.
+     0b01111110, // .OOOOOO.
+     0b01111110, // .OOOOOO.
+     0b01111110, // .OOOOOO.
+     0b01111110, // .OOOOOO.
+     0b01111110, // .OOOOOO.
+     0b01111110, // .OOOOOO.
+     0b00000000, // ........
+     /* 008 */
+     0b00000000, // ........
+     0b01111110, // .OOOOOO.
+     0b01000010, // .O....O.
+     0b01000010, // .O....O.
+     0b01000010, // .O....O.
+     0b01000010, // .O....O.
+     0b01000010, // .O....O.
+     0b01000010, // .O....O.
+     0b01000010, // .O....O.
+     0b01000010, // .O....O.
+     0b01111110, // .OOOOOO.
+     0b00000000, // ........
      /* 009 */ 
      0x00,0x00,  // ............
      0x00,0x00,  // ............

--- a/Core/Inc/retro-go/fonts/font_cp1252_Serif_Bold.h
+++ b/Core/Inc/retro-go/fonts/font_cp1252_Serif_Bold.h
@@ -86,31 +86,31 @@ const char font_cp1252_Serif_Bold[] FONT_DATA = {
      0xf0,0x0f,  // ....OOOOOOOO....
      0x00,0x00,  // ................
      /* 007 */ 
-     0xff, // OOOOOOOO
-     0xff, // OOOOOOOO
-     0xff, // OOOOOOOO
-     0xff, // OOOOOOOO
-     0xff, // OOOOOOOO
-     0xff, // OOOOOOOO
-     0xff, // OOOOOOOO
-     0xff, // OOOOOOOO
-     0xff, // OOOOOOOO
-     0xff, // OOOOOOOO
-     0xff, // OOOOOOOO
-     0xff, // OOOOOOOO
-     /* 008 */ 
-     0xfe, // .OOOOOOO
-     0x82, // .O.....O
-     0x82, // .O.....O
-     0x82, // .O.....O
-     0x82, // .O.....O
-     0x82, // .O.....O
-     0x82, // .O.....O
-     0x82, // .O.....O
-     0x82, // .O.....O
-     0x82, // .O.....O
-     0x82, // .O.....O
-     0xfe, // .OOOOOOO
+     0b00000000, // ........
+     0b01111110, // .OOOOOO.
+     0b01111110, // .OOOOOO.
+     0b01111110, // .OOOOOO.
+     0b01111110, // .OOOOOO.
+     0b01111110, // .OOOOOO.
+     0b01111110, // .OOOOOO.
+     0b01111110, // .OOOOOO.
+     0b01111110, // .OOOOOO.
+     0b01111110, // .OOOOOO.
+     0b01111110, // .OOOOOO.
+     0b00000000, // ........
+     /* 008 */
+     0b00000000, // ........
+     0b01111110, // .OOOOOO.
+     0b01000010, // .O....O.
+     0b01000010, // .O....O.
+     0b01000010, // .O....O.
+     0b01000010, // .O....O.
+     0b01000010, // .O....O.
+     0b01000010, // .O....O.
+     0b01000010, // .O....O.
+     0b01000010, // .O....O.
+     0b01111110, // .OOOOOO.
+     0b00000000, // ........
      /* 009 */ 
      0x00,0x00,  // ............
      0x00,0x00,  // ............

--- a/Core/Inc/retro-go/fonts/font_cp1252_Serif_CJK.h
+++ b/Core/Inc/retro-go/fonts/font_cp1252_Serif_CJK.h
@@ -86,31 +86,31 @@ const char font_cp1252_Serif_CJK[] FONT_DATA = {
      0xf0,0x0f,  // ....OOOOOOOO....
      0x00,0x00,  // ................
      /* 007 */ 
-     0xff, // OOOOOOOO
-     0xff, // OOOOOOOO
-     0xff, // OOOOOOOO
-     0xff, // OOOOOOOO
-     0xff, // OOOOOOOO
-     0xff, // OOOOOOOO
-     0xff, // OOOOOOOO
-     0xff, // OOOOOOOO
-     0xff, // OOOOOOOO
-     0xff, // OOOOOOOO
-     0xff, // OOOOOOOO
-     0xff, // OOOOOOOO
-     /* 008 */ 
-     0xfe, // .OOOOOOO
-     0x82, // .O.....O
-     0x82, // .O.....O
-     0x82, // .O.....O
-     0x82, // .O.....O
-     0x82, // .O.....O
-     0x82, // .O.....O
-     0x82, // .O.....O
-     0x82, // .O.....O
-     0x82, // .O.....O
-     0x82, // .O.....O
-     0xfe, // .OOOOOOO
+     0b00000000, // ........
+     0b01111110, // .OOOOOO.
+     0b01111110, // .OOOOOO.
+     0b01111110, // .OOOOOO.
+     0b01111110, // .OOOOOO.
+     0b01111110, // .OOOOOO.
+     0b01111110, // .OOOOOO.
+     0b01111110, // .OOOOOO.
+     0b01111110, // .OOOOOO.
+     0b01111110, // .OOOOOO.
+     0b01111110, // .OOOOOO.
+     0b00000000, // ........
+     /* 008 */
+     0b00000000, // ........
+     0b01111110, // .OOOOOO.
+     0b01000010, // .O....O.
+     0b01000010, // .O....O.
+     0b01000010, // .O....O.
+     0b01000010, // .O....O.
+     0b01000010, // .O....O.
+     0b01000010, // .O....O.
+     0b01000010, // .O....O.
+     0b01000010, // .O....O.
+     0b01111110, // .OOOOOO.
+     0b00000000, // ........
      /* 009 */ 
      0x00,0x00,  // ............
      0x00,0x00,  // ............

--- a/Core/Inc/retro-go/fonts/font_cp1252_Unbalanced.h
+++ b/Core/Inc/retro-go/fonts/font_cp1252_Unbalanced.h
@@ -86,31 +86,31 @@ const char font_cp1252_Unbalanced[] FONT_DATA = {
      0xf0,0x0f,  // ....OOOOOOOO....
      0x00,0x00,  // ................
      /* 007 */ 
-     0xff, // OOOOOOOO
-     0xff, // OOOOOOOO
-     0xff, // OOOOOOOO
-     0xff, // OOOOOOOO
-     0xff, // OOOOOOOO
-     0xff, // OOOOOOOO
-     0xff, // OOOOOOOO
-     0xff, // OOOOOOOO
-     0xff, // OOOOOOOO
-     0xff, // OOOOOOOO
-     0xff, // OOOOOOOO
-     0xff, // OOOOOOOO
-     /* 008 */ 
-     0xfe, // .OOOOOOO
-     0x82, // .O.....O
-     0x82, // .O.....O
-     0x82, // .O.....O
-     0x82, // .O.....O
-     0x82, // .O.....O
-     0x82, // .O.....O
-     0x82, // .O.....O
-     0x82, // .O.....O
-     0x82, // .O.....O
-     0x82, // .O.....O
-     0xfe, // .OOOOOOO
+     0b00000000, // ........
+     0b01111110, // .OOOOOO.
+     0b01111110, // .OOOOOO.
+     0b01111110, // .OOOOOO.
+     0b01111110, // .OOOOOO.
+     0b01111110, // .OOOOOO.
+     0b01111110, // .OOOOOO.
+     0b01111110, // .OOOOOO.
+     0b01111110, // .OOOOOO.
+     0b01111110, // .OOOOOO.
+     0b01111110, // .OOOOOO.
+     0b00000000, // ........
+     /* 008 */
+     0b00000000, // ........
+     0b01111110, // .OOOOOO.
+     0b01000010, // .O....O.
+     0b01000010, // .O....O.
+     0b01000010, // .O....O.
+     0b01000010, // .O....O.
+     0b01000010, // .O....O.
+     0b01000010, // .O....O.
+     0b01000010, // .O....O.
+     0b01000010, // .O....O.
+     0b01111110, // .OOOOOO.
+     0b00000000, // ........
      /* 009 */ 
      0x00,0x00,  // ............
      0x00,0x00,  // ............

--- a/Core/Inc/retro-go/fonts/font_cp1252_haeberli12.h
+++ b/Core/Inc/retro-go/fonts/font_cp1252_haeberli12.h
@@ -86,31 +86,31 @@ const char font_cp1252_haeberli12[] FONT_DATA = {
      0xf0,0x0f,  // ....OOOOOOOO....
      0x00,0x00,  // ................
      /* 007 */ 
-     0xff, // OOOOOOOO
-     0xff, // OOOOOOOO
-     0xff, // OOOOOOOO
-     0xff, // OOOOOOOO
-     0xff, // OOOOOOOO
-     0xff, // OOOOOOOO
-     0xff, // OOOOOOOO
-     0xff, // OOOOOOOO
-     0xff, // OOOOOOOO
-     0xff, // OOOOOOOO
-     0xff, // OOOOOOOO
-     0xff, // OOOOOOOO
-     /* 008 */ 
-     0xfe, // .OOOOOOO
-     0x82, // .O.....O
-     0x82, // .O.....O
-     0x82, // .O.....O
-     0x82, // .O.....O
-     0x82, // .O.....O
-     0x82, // .O.....O
-     0x82, // .O.....O
-     0x82, // .O.....O
-     0x82, // .O.....O
-     0x82, // .O.....O
-     0xfe, // .OOOOOOO
+     0b00000000, // ........
+     0b01111110, // .OOOOOO.
+     0b01111110, // .OOOOOO.
+     0b01111110, // .OOOOOO.
+     0b01111110, // .OOOOOO.
+     0b01111110, // .OOOOOO.
+     0b01111110, // .OOOOOO.
+     0b01111110, // .OOOOOO.
+     0b01111110, // .OOOOOO.
+     0b01111110, // .OOOOOO.
+     0b01111110, // .OOOOOO.
+     0b00000000, // ........
+     /* 008 */
+     0b00000000, // ........
+     0b01111110, // .OOOOOO.
+     0b01000010, // .O....O.
+     0b01000010, // .O....O.
+     0b01000010, // .O....O.
+     0b01000010, // .O....O.
+     0b01000010, // .O....O.
+     0b01000010, // .O....O.
+     0b01000010, // .O....O.
+     0b01000010, // .O....O.
+     0b01111110, // .OOOOOO.
+     0b00000000, // ........
      /* 009 */ 
      0x00,0x00,  // ............
      0x00,0x00,  // ............

--- a/Core/Inc/retro-go/fonts/font_cp1252_rock12.h
+++ b/Core/Inc/retro-go/fonts/font_cp1252_rock12.h
@@ -85,32 +85,32 @@ const char font_cp1252_rock12[] FONT_DATA = {
      0x0c,0x30,  // ..OO........OO..
      0xf0,0x0f,  // ....OOOOOOOO....
      0x00,0x00,  // ................
-     /* 007 */ 
-     0xff, // OOOOOOOO
-     0xff, // OOOOOOOO
-     0xff, // OOOOOOOO
-     0xff, // OOOOOOOO
-     0xff, // OOOOOOOO
-     0xff, // OOOOOOOO
-     0xff, // OOOOOOOO
-     0xff, // OOOOOOOO
-     0xff, // OOOOOOOO
-     0xff, // OOOOOOOO
-     0xff, // OOOOOOOO
-     0xff, // OOOOOOOO
-     /* 008 */ 
-     0xfe, // .OOOOOOO
-     0x82, // .O.....O
-     0x82, // .O.....O
-     0x82, // .O.....O
-     0x82, // .O.....O
-     0x82, // .O.....O
-     0x82, // .O.....O
-     0x82, // .O.....O
-     0x82, // .O.....O
-     0x82, // .O.....O
-     0x82, // .O.....O
-     0xfe, // .OOOOOOO
+     /* 007 */
+     0b00000000, // ........
+     0b01111110, // .OOOOOO.
+     0b01111110, // .OOOOOO.
+     0b01111110, // .OOOOOO.
+     0b01111110, // .OOOOOO.
+     0b01111110, // .OOOOOO.
+     0b01111110, // .OOOOOO.
+     0b01111110, // .OOOOOO.
+     0b01111110, // .OOOOOO.
+     0b01111110, // .OOOOOO.
+     0b01111110, // .OOOOOO.
+     0b00000000, // ........
+     /* 008 */
+     0b00000000, // ........
+     0b01111110, // .OOOOOO.
+     0b01000010, // .O....O.
+     0b01000010, // .O....O.
+     0b01000010, // .O....O.
+     0b01000010, // .O....O.
+     0b01000010, // .O....O.
+     0b01000010, // .O....O.
+     0b01000010, // .O....O.
+     0b01000010, // .O....O.
+     0b01111110, // .OOOOOO.
+     0b00000000, // ........
      /* 009 */ 
      0x00,0x00,  // ............
      0x00,0x00,  // ............


### PR DESCRIPTION
I suggest that the two font tiles used in the horizontal bargraph should be changed to include a "no pixel" border around them to make them more pleasing. I understand that this is a matter of taste but give it a try. I have updated all the supported fonts with the two updated tiles.

Here is a before picture
https://ibb.co/JkRtPnt
And here is a after picture.
https://ibb.co/HdnFyjZ

This improvement will also serve a later fix where we don't invert it when a bar graph item is selected.