### PR TITLE
System timeout rounded to minute and max 1 hour

### DIFF
--- a/Core/Src/porting/odroid_settings.c
+++ b/Core/Src/porting/odroid_settings.c
@@ -449,7 +449,7 @@ void odroid_settings_StartupFile_set(void *value)
 
 uint16_t odroid_settings_MainMenuTimeoutS_get()
 {
-    return persistent_config_ram.main_menu_timeout_s;
+    return ((MIN(persistent_config_ram.main_menu_timeout_s, 3600) + 59) / 60) * 60; // > 0 : Round to whole minutes max one hour
 }
 void odroid_settings_MainMenuTimeoutS_set(uint16_t value)
 {


### PR DESCRIPTION
Currently the timeout is set in seconds but my suggestion would be to change this to minutes. 
The range could be from 0 to 60 minutes as I believe this could cover most if not all usecases,
I believe this is a more user friendly and pleasing experience. Please also see #24 