### PR TITLE
Removed LCD OFF segments from clock to improve readability

### DIFF
--- a/Core/Src/porting/odroid_overlay.c
+++ b/Core/Src/porting/odroid_overlay.c
@@ -208,20 +208,17 @@ void odroid_overlay_clock(int x_pos, int y_pos)
     HAL_RTC_GetTime(&hrtc, &GW_currentTime, RTC_FORMAT_BIN);
     HAL_RTC_GetDate(&hrtc, &GW_currentDate, RTC_FORMAT_BIN);
 
-    uint16_t color = get_darken_pixel(curr_colors->main_c, 75);
-    draw_clock_digit(dst_img, 8, x_pos + 30, y_pos, color);
-    draw_clock_digit(dst_img, 8, x_pos + 22, y_pos, color);
-    draw_clock_digit(dst_img, 8, x_pos + 8, y_pos, color);
-    draw_clock_digit(dst_img, 8, x_pos, y_pos, color);
+    uint16_t color = curr_colors->sel_c;
+    draw_clock_digit(dst_img, GW_currentTime.Minutes % 10, x_pos + 30, y_pos, color);
+    draw_clock_digit(dst_img, GW_currentTime.Minutes / 10, x_pos + 22, y_pos, color);
+    draw_clock_digit(dst_img, GW_currentTime.Hours % 10, x_pos + 8, y_pos, color);
+    draw_clock_digit(dst_img, GW_currentTime.Hours / 10, x_pos, y_pos, color);
 
-    draw_clock_digit(dst_img, GW_currentTime.Minutes % 10, x_pos + 30, y_pos, curr_colors->sel_c);
-    draw_clock_digit(dst_img, GW_currentTime.Minutes / 10, x_pos + 22, y_pos, curr_colors->sel_c);
-    draw_clock_digit(dst_img, GW_currentTime.Hours % 10, x_pos + 8, y_pos, curr_colors->sel_c);
-    draw_clock_digit(dst_img, GW_currentTime.Hours / 10, x_pos, y_pos, curr_colors->sel_c);
-    
-    color = (GW_currentTime.SubSeconds < 100) ? curr_colors->sel_c : get_darken_pixel(curr_colors->main_c, 75);
-    odroid_overlay_draw_fill_rect(x_pos + 17, y_pos + 2, 2, 2, color);
-    odroid_overlay_draw_fill_rect(x_pos + 17, y_pos + 6, 2, 2, color);
+    if (GW_currentTime.SubSeconds < 100)
+    {
+        odroid_overlay_draw_fill_rect(x_pos + 17, y_pos + 2, 2, 2, color);
+        odroid_overlay_draw_fill_rect(x_pos + 17, y_pos + 6, 2, 2, color);
+    }
 };
 
 


### PR DESCRIPTION
I know that the OFF segments on a real and "old school" LCD (and a real G&W) is slightly visible as an artifact but it is slightly detracting from the readability of the time. So I suggest that we remove it. I have provided a PR that does exactly this for you to decide.

Old picture of time:
https://ibb.co/hDrjx4k
New picture of time:
https://ibb.co/dJfNkz4