### PR TITLE
Fixed an issue where options where selectable purely for it box color property

### DIFF
--- a/Core/Src/retro-go/rg_emulators.c
+++ b/Core/Src/retro-go/rg_emulators.c
@@ -317,11 +317,11 @@ void emulator_show_file_info(retro_emulator_file_t *file)
     //crc_value[0] = '\x00';
 
     odroid_dialog_choice_t choices[] = {
-        {0, curr_lang->s_File, filename_value, 1, NULL},
-        {0, curr_lang->s_Type, type_value, 1, NULL},
-        {0, curr_lang->s_Size, size_value, 1, NULL},
+        {-1, curr_lang->s_File, filename_value, 0, NULL},
+        {-1, curr_lang->s_Type, type_value, 0, NULL},
+        {-1, curr_lang->s_Size, size_value, 0, NULL},
 		#if COVERFLOW != 0
-        {0, curr_lang->s_ImgSize, img_size, 1, NULL},
+        {-1, curr_lang->s_ImgSize, img_size, 0, NULL},
 		#endif
         ODROID_DIALOG_CHOICE_SEPARATOR,
         {1, curr_lang->s_Close, "", 1, NULL},

--- a/Core/Src/retro-go/rg_main.c
+++ b/Core/Src/retro-go/rg_main.c
@@ -380,15 +380,15 @@ void retro_loop()
             if ((last_key == ODROID_INPUT_START) || (last_key == ODROID_INPUT_X))
             {
                 odroid_dialog_choice_t choices[] = {
-                    {9, curr_lang->s_Version, GIT_HASH, 1, NULL},
-                    {9, curr_lang->s_Author, "ducalex", 1, NULL},
-                    {9, curr_lang->s_Author_, "kbeckmann", 1, NULL},
-                    {9, curr_lang->s_Author_, "stacksmashing", 1, NULL},
-                    {9, curr_lang->s_Author_, "Sylver Bruneau", 1, NULL},
-                    {9, curr_lang->s_Author_, "bzhxx", 1, NULL},
-                    {9, curr_lang->s_UI_Mod, "orzeus", 1, NULL},
+                    {-1, curr_lang->s_Version, GIT_HASH, 0, NULL},
+                    {-1, curr_lang->s_Author, "ducalex", 0, NULL},
+                    {-1, curr_lang->s_Author_, "kbeckmann", 0, NULL},
+                    {-1, curr_lang->s_Author_, "stacksmashing", 0, NULL},
+                    {-1, curr_lang->s_Author_, "Sylver Bruneau", 0, NULL},
+                    {-1, curr_lang->s_Author_, "bzhxx", 0, NULL},
+                    {-1, curr_lang->s_UI_Mod, "orzeus", 0, NULL},
                     ODROID_DIALOG_CHOICE_SEPARATOR,
-                    {1, curr_lang->s_Lang, curr_lang->s_LangAuthor, 1, NULL},
+                    {-1, curr_lang->s_Lang, curr_lang->s_LangAuthor, 0, NULL},
                     ODROID_DIALOG_CHOICE_SEPARATOR,
                     {2, curr_lang->s_Debug_menu, "", 1, NULL},
                     {1, curr_lang->s_Reset_settings, "", 1, NULL},
@@ -434,13 +434,13 @@ void retro_loop()
                     snprintf(dbgmcu_cr_str, sizeof(dbgmcu_cr_str), "0x%08lX", DBGMCU->CR);
 
                     odroid_dialog_choice_t debuginfo[] = {
-                        {0, curr_lang->s_Flash_JEDEC_ID, (char *)jedec_id_str, 1, NULL},
-                        {0, curr_lang->s_Flash_Name, (char *)OSPI_GetFlashName(), 1, NULL},
-                        {0, curr_lang->s_Flash_SR, (char *)status_str, 1, NULL},
-                        {0, curr_lang->s_Flash_CR, (char *)config_str, 1, NULL},
-                        {0, curr_lang->s_Smallest_erase, erase_size_str, 1, NULL},
+                        {-1, curr_lang->s_Flash_JEDEC_ID, (char *)jedec_id_str, 0, NULL},
+                        {-1, curr_lang->s_Flash_Name, (char *)OSPI_GetFlashName(), 0, NULL},
+                        {-1, curr_lang->s_Flash_SR, (char *)status_str, 0, NULL},
+                        {-1, curr_lang->s_Flash_CR, (char *)config_str, 0, NULL},
+                        {-1, curr_lang->s_Smallest_erase, erase_size_str, 0, NULL},
                         ODROID_DIALOG_CHOICE_SEPARATOR,
-                        {0, curr_lang->s_DBGMCU_IDCODE, dbgmcu_id_str, 1, NULL},
+                        {-1, curr_lang->s_DBGMCU_IDCODE, dbgmcu_id_str, 0, NULL},
                         {1, curr_lang->s_Enable_DBGMCU_CK, dbgmcu_cr_str, 1, NULL},
                         {2, curr_lang->s_Disable_DBGMCU_CK, "", 1, NULL},
                         ODROID_DIALOG_CHOICE_SEPARATOR,


### PR DESCRIPTION
Changed option items, so they can be functionally disabled but still retain there box color.

Now items can have there (int) enabled variable set to :

-1 for disabled and be printed in disabled color,
0 for disabled and be printed in box color,
1 for enabled and be printed in box color.

Updated options across the system where options, that were enabled but clearly should have been disabled but also still be printed in box color.

This fixes "non functional" option selection in "YES/NO" dialog boxes, the "About box" and the "Debug info" box.