### PR TITLE
RTC date time handling rewrite

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -42,3 +42,7 @@ venv
 
 .vs/*
 .vscode/*
+
+.clang-format
+.idea/
+cmake-build-debug

--- a/Core/Inc/retro-go/rg_rtc.h
+++ b/Core/Inc/retro-go/rg_rtc.h
@@ -16,12 +16,13 @@ extern "C" {
 uint8_t GW_GetCurrentHour(void);
 uint8_t GW_GetCurrentMinute(void);
 uint8_t GW_GetCurrentSecond(void);
-uint32_t GW_GetCurrentSubSeconds(void);
+uint8_t GW_GetCurrentSubSeconds(void);
 
 uint8_t GW_GetCurrentMonth(void);
 uint8_t GW_GetCurrentDay(void);
 uint8_t GW_GetCurrentWeekday(void);
 uint8_t GW_GetCurrentYear(void);
+uint64_t GW_GetCurrentMillis(void);
 
 time_t GW_GetUnixTime(void);
 void GW_GetUnixTM(struct tm *tm);

--- a/Core/Inc/retro-go/rg_rtc.h
+++ b/Core/Inc/retro-go/rg_rtc.h
@@ -40,20 +40,6 @@ void GW_SetCurrentDay(const uint8_t day);
 void GW_SetCurrentWeekday(const uint8_t weekday);
 void GW_SetCurrentYear(const uint8_t year);
 
-// Callbacks for UI purposes
-bool hour_update_cb(odroid_dialog_choice_t *option, odroid_dialog_event_t event, uint32_t repeat);
-bool minute_update_cb(odroid_dialog_choice_t *option, odroid_dialog_event_t event, uint32_t repeat);
-bool second_update_cb(odroid_dialog_choice_t *option, odroid_dialog_event_t event, uint32_t repeat);
-
-bool month_update_cb(odroid_dialog_choice_t *option, odroid_dialog_event_t event, uint32_t repeat);
-bool day_update_cb(odroid_dialog_choice_t *option, odroid_dialog_event_t event, uint32_t repeat);
-
-bool weekday_update_cb(odroid_dialog_choice_t *option, odroid_dialog_event_t event, uint32_t repeat);
-bool year_update_cb(odroid_dialog_choice_t *option, odroid_dialog_event_t event, uint32_t repeat);
-
-bool time_display_cb(odroid_dialog_choice_t *option, odroid_dialog_event_t event, uint32_t repeat);
-bool date_display_cb(odroid_dialog_choice_t *option, odroid_dialog_event_t event, uint32_t repeat);
-
 #ifdef __cplusplus
 }
 #endif

--- a/Core/Inc/retro-go/rg_rtc.h
+++ b/Core/Inc/retro-go/rg_rtc.h
@@ -1,18 +1,14 @@
-#ifndef _GW_RTC_H_
-#define _GW_RTC_H_
+#pragma once
+
+#ifndef _RG_RTC_H_
+#define _RG_RTC_H_
 
 #ifdef __cplusplus
 extern "C" {
 #endif
 
 /* Includes ------------------------------------------------------------------*/
-#include "stm32h7xx_hal.h"
-#include "odroid_system.h"
-
-/* Exported constants --------------------------------------------------------*/
-extern RTC_TimeTypeDef GW_currentTime;
-extern RTC_DateTypeDef GW_currentDate;
-extern const char * GW_RTC_Weekday[];
+#include <time.h>
 
 /* Exported functions prototypes ---------------------------------------------*/
 
@@ -20,25 +16,25 @@ extern const char * GW_RTC_Weekday[];
 uint8_t GW_GetCurrentHour(void);
 uint8_t GW_GetCurrentMinute(void);
 uint8_t GW_GetCurrentSecond(void);
+uint32_t GW_GetCurrentSubSeconds(void);
 
 uint8_t GW_GetCurrentMonth(void);
 uint8_t GW_GetCurrentDay(void);
-
 uint8_t GW_GetCurrentWeekday(void);
 uint8_t GW_GetCurrentYear(void);
 
 time_t GW_GetUnixTime(void);
+void GW_GetUnixTM(struct tm *tm);
+void GW_SetUnixTM(struct tm *tm);
 
 // Setters
-void GW_SetCurrentHour(const uint8_t hour);
-void GW_SetCurrentMinute(const uint8_t minute);
-void GW_SetCurrentSecond(const uint8_t second);
+void GW_AddToCurrentHour(const int8_t direction);
+void GW_AddToCurrentMinute(const int8_t direction);
+void GW_AddToCurrentSecond(const int8_t direction);
 
-void GW_SetCurrentMonth(const uint8_t month);
-void GW_SetCurrentDay(const uint8_t day);
-
-void GW_SetCurrentWeekday(const uint8_t weekday);
-void GW_SetCurrentYear(const uint8_t year);
+void GW_AddToCurrentMonth(const int8_t direction);
+void GW_AddToCurrentDay(const int8_t direction);
+void GW_AddToCurrentYear(const int8_t direction);
 
 #ifdef __cplusplus
 }

--- a/Core/Src/porting/gw/main_gw.c
+++ b/Core/Src/porting/gw/main_gw.c
@@ -19,6 +19,7 @@
 #include "rom_manager.h"
 #include "rg_i18n.h"
 #include "gui.h"
+#include "rg_rtc.h"
 
 /* G&W system support */
 #include "gw_system.h"
@@ -47,15 +48,13 @@ static unsigned int softkey_duration = 0;
 
 static void gw_set_time() {
 
-    // Get time. According to STM docs, both functions need to be called at once.
-    RTC_TimeTypeDef GW_currentTime = {0};
-    RTC_DateTypeDef GW_currentDate = {0};
+    struct tm tm;
+    GW_GetUnixTM(&tm);
+
     gw_time_t time;
-    HAL_RTC_GetTime(&hrtc, &GW_currentTime, RTC_FORMAT_BIN);
-    HAL_RTC_GetDate(&hrtc, &GW_currentDate, RTC_FORMAT_BIN);
-    time.hours = GW_currentTime.Hours;
-    time.minutes = GW_currentTime.Minutes;
-    time.seconds = GW_currentTime.Seconds;
+    time.hours = tm.tm_hour;
+    time.minutes = tm.tm_min;
+    time.seconds = tm.tm_sec;
 
     // set time of the emulated system
     gw_system_set_time(time);
@@ -64,46 +63,33 @@ static void gw_set_time() {
 
 static void gw_get_time() {
 
-    // Update time before we can set it
-    RTC_TimeTypeDef GW_currentTime = {0};
-    RTC_DateTypeDef GW_currentDate = {0};
     gw_time_t time = {0};
 
     // check if the system is able to get the time
-
     time = gw_system_get_time();
     if (time.hours > 24) return;
 
-    HAL_RTC_GetTime(&hrtc, &GW_currentTime, RTC_FORMAT_BIN);
-    HAL_RTC_GetDate(&hrtc, &GW_currentDate, RTC_FORMAT_BIN);
-
     // Set times
-    GW_currentTime.Hours = time.hours;
-    GW_currentTime.Minutes = time.minutes;
-    GW_currentTime.Seconds = time.seconds;
-
-    if (HAL_RTC_SetTime(&hrtc, &GW_currentTime, RTC_FORMAT_BIN) != HAL_OK)
-    {
-        Error_Handler();
-    }
+    struct tm tm;
+    GW_GetUnixTM(&tm);
+    tm.tm_hour = time.hours;
+    tm.tm_min = time.minutes;
+    tm.tm_sec = time.seconds;
+    GW_SetUnixTM(&tm);
 }
 
 static void gw_check_time() {
 
     static unsigned int is_gw_time_sync=0;
 
-    // Update time before we can set it
-    RTC_TimeTypeDef GW_currentTime = {0};
-    RTC_DateTypeDef GW_currentDate = {0};
-    gw_time_t time = {0};
-
-    HAL_RTC_GetTime(&hrtc, &GW_currentTime, RTC_FORMAT_BIN);
-    HAL_RTC_GetDate(&hrtc, &GW_currentDate, RTC_FORMAT_BIN);
+    struct tm tm;
+    GW_GetUnixTM(&tm);
 
     // Set times
-    time.hours = GW_currentTime.Hours;
-    time.minutes = GW_currentTime.Minutes;
-    time.seconds = GW_currentTime.Seconds;
+    gw_time_t time;
+    time.hours = tm.tm_hour;
+    time.minutes = tm.tm_min;
+    time.seconds = tm.tm_sec;
 
     // update time every 30s
     if ( (time.seconds == 30) || (is_gw_time_sync==0) ) {

--- a/Core/Src/porting/odroid_overlay.c
+++ b/Core/Src/porting/odroid_overlay.c
@@ -205,8 +205,6 @@ static void draw_clock_digit(uint16_t *fb, const uint8_t clock, uint16_t px, uin
 void odroid_overlay_clock(int x_pos, int y_pos)
 {
     uint16_t *dst_img = lcd_get_active_buffer();
-    HAL_RTC_GetTime(&hrtc, &GW_currentTime, RTC_FORMAT_BIN);
-    HAL_RTC_GetDate(&hrtc, &GW_currentDate, RTC_FORMAT_BIN);
 
 #ifdef RETRO_LCD_CLOCK_ARTIFACTS
     uint16_t color = get_darken_pixel(curr_colors->main_c, 75);
@@ -219,13 +217,16 @@ void odroid_overlay_clock(int x_pos, int y_pos)
 #else
     uint16_t color = (GW_currentTime.SubSeconds < 100) ? curr_colors->sel_c : curr_colors->main_c;
 #endif
+
     odroid_overlay_draw_fill_rect(x_pos + 17, y_pos + 2, 2, 2, color);
     odroid_overlay_draw_fill_rect(x_pos + 17, y_pos + 6, 2, 2, color);
 
-    draw_clock_digit(dst_img, GW_currentTime.Minutes % 10, x_pos + 30, y_pos, curr_colors->sel_c);
-    draw_clock_digit(dst_img, GW_currentTime.Minutes / 10, x_pos + 22, y_pos, curr_colors->sel_c);
-    draw_clock_digit(dst_img, GW_currentTime.Hours % 10, x_pos + 8, y_pos, curr_colors->sel_c);
-    draw_clock_digit(dst_img, GW_currentTime.Hours / 10, x_pos, y_pos, curr_colors->sel_c);
+    int minute = GW_GetCurrentMinute();
+    int hour = GW_GetCurrentHour();
+    draw_clock_digit(dst_img, minute % 10, x_pos + 30, y_pos, curr_colors->sel_c);
+    draw_clock_digit(dst_img, minute / 10, x_pos + 22, y_pos, curr_colors->sel_c);
+    draw_clock_digit(dst_img, hour % 10, x_pos + 8, y_pos, curr_colors->sel_c);
+    draw_clock_digit(dst_img, hour / 10, x_pos, y_pos, curr_colors->sel_c);
 };
 
 

--- a/Core/Src/porting/odroid_overlay.c
+++ b/Core/Src/porting/odroid_overlay.c
@@ -213,9 +213,9 @@ void odroid_overlay_clock(int x_pos, int y_pos)
     draw_clock_digit(dst_img, 8, x_pos + 8, y_pos, color);
     draw_clock_digit(dst_img, 8, x_pos, y_pos, color);
 
-    color = (GW_GetCurrentSubSeconds() < 125) ? curr_colors->sel_c : color;
+    color = (GW_GetCurrentSubSeconds() <= 127) ? curr_colors->sel_c : color;
 #else
-    uint16_t color = (GW_GetCurrentSubSeconds() < 125) ? curr_colors->sel_c : curr_colors->main_c;
+    uint16_t color = (GW_GetCurrentSubSeconds() <= 127) ? curr_colors->sel_c : curr_colors->main_c;
 #endif
 
     odroid_overlay_draw_fill_rect(x_pos + 17, y_pos + 2, 2, 2, color);
@@ -353,6 +353,7 @@ uint16_t get_shined_pixel(uint16_t color, uint16_t shined)
     return r | g | b;
 }
 
+__attribute__((optimize("unroll-loops")))
 void odroid_overlay_darken_all()
 {
     if (dialog_open_depth <= 0)

--- a/Core/Src/porting/odroid_overlay.c
+++ b/Core/Src/porting/odroid_overlay.c
@@ -213,9 +213,9 @@ void odroid_overlay_clock(int x_pos, int y_pos)
     draw_clock_digit(dst_img, 8, x_pos + 8, y_pos, color);
     draw_clock_digit(dst_img, 8, x_pos, y_pos, color);
 
-    color = (GW_currentTime.SubSeconds < 100) ? curr_colors->sel_c : color;
+    color = (GW_GetCurrentSubSeconds() < 125) ? curr_colors->sel_c : color;
 #else
-    uint16_t color = (GW_currentTime.SubSeconds < 100) ? curr_colors->sel_c : curr_colors->main_c;
+    uint16_t color = (GW_GetCurrentSubSeconds() < 125) ? curr_colors->sel_c : curr_colors->main_c;
 #endif
 
     odroid_overlay_draw_fill_rect(x_pos + 17, y_pos + 2, 2, 2, color);

--- a/Core/Src/retro-go/rg_main.c
+++ b/Core/Src/retro-go/rg_main.c
@@ -267,198 +267,100 @@ static bool lang_update_cb(odroid_dialog_choice_t *option, odroid_dialog_event_t
 
 bool hour_update_cb(odroid_dialog_choice_t *option, odroid_dialog_event_t event, uint32_t repeat)
 {
-    int8_t hour = GW_GetCurrentHour();
-    int8_t min = 0;
-    int8_t max = 23;
-
     if (event == ODROID_DIALOG_PREV) {
-        if (hour == min)
-            hour = max;
-        else
-            hour--;
-        GW_SetCurrentHour(hour);
+        GW_AddToCurrentHour(-1);
     }
     else if (event == ODROID_DIALOG_NEXT) {
-        if (hour == max)
-            hour = min;
-        else
-            hour++;
-        GW_SetCurrentHour(hour);
+        GW_AddToCurrentHour(1);
     }
 
-    sprintf(option->value, "%02d", hour);
+    sprintf(option->value, "%02d", GW_GetCurrentHour());
     return event == ODROID_DIALOG_ENTER;
 }
 
 bool minute_update_cb(odroid_dialog_choice_t *option, odroid_dialog_event_t event, uint32_t repeat)
 {
-    int8_t minute = GW_GetCurrentMinute();
-    int8_t min = 0;
-    int8_t max = 59;
-
     if (event == ODROID_DIALOG_PREV) {
-        if (minute == min)
-            minute = max;
-        else
-            minute--;
-        GW_SetCurrentMinute(minute);
+        GW_AddToCurrentMinute(-1);
     }
     else if (event == ODROID_DIALOG_NEXT) {
-        if (minute == max)
-            minute = min;
-        else
-            minute++;
-        GW_SetCurrentMinute(minute);
+        GW_AddToCurrentMinute(1);
     }
 
-    sprintf(option->value, "%02d", minute);
+    sprintf(option->value, "%02d", GW_GetCurrentMinute());
     return event == ODROID_DIALOG_ENTER;
 }
 
 bool second_update_cb(odroid_dialog_choice_t *option, odroid_dialog_event_t event, uint32_t repeat)
 {
-    int8_t second = GW_GetCurrentSecond();
-    int8_t min = 0;
-    int8_t max = 59;
-
     if (event == ODROID_DIALOG_PREV) {
-        if (second == min)
-            second = max;
-        else
-            second--;
-        GW_SetCurrentSecond(second);
+        GW_AddToCurrentSecond(-1);
     }
     else if (event == ODROID_DIALOG_NEXT) {
-        if (second == max)
-            second = min;
-        else
-            second++;
-        GW_SetCurrentSecond(second);
+        GW_AddToCurrentSecond(1);
     }
 
-    sprintf(option->value, "%02d", second);
+    sprintf(option->value, "%02d", GW_GetCurrentSecond());
     return event == ODROID_DIALOG_ENTER;
 }
 
 bool day_update_cb(odroid_dialog_choice_t *option, odroid_dialog_event_t event, uint32_t repeat)
 {
-    int8_t day = GW_GetCurrentDay();
-    int8_t min = 1;
-    int8_t max = 31;
-
     if (event == ODROID_DIALOG_PREV) {
-        if (day == min)
-            day = max;
-        else
-            day--;
-        GW_SetCurrentDay(day);
+        GW_AddToCurrentDay(-1);
     }
     else if (event == ODROID_DIALOG_NEXT) {
-        if (day == max)
-            day = min;
-        else
-            day++;
-        GW_SetCurrentDay(day);
+        GW_AddToCurrentDay(1);
     }
 
-    sprintf(option->value, "%02d", day);
+    sprintf(option->value, "%02d", GW_GetCurrentDay());
     return event == ODROID_DIALOG_ENTER;
 }
 
 bool weekday_update_cb(odroid_dialog_choice_t *option, odroid_dialog_event_t event, uint32_t repeat)
 {
     const char * GW_RTC_Weekday[] = {curr_lang->s_Weekday_Mon, curr_lang->s_Weekday_Tue, curr_lang->s_Weekday_Wed, curr_lang->s_Weekday_Thu, curr_lang->s_Weekday_Fri, curr_lang->s_Weekday_Sat, curr_lang->s_Weekday_Sun};
-
-    int8_t weekday = GW_GetCurrentWeekday();
-    int8_t min = 1;
-    int8_t max = 7;
-
-    if (event == ODROID_DIALOG_PREV) {
-        if (weekday == min)
-            weekday = max;
-        else
-            weekday--;
-        GW_SetCurrentWeekday(weekday);
-    }
-    else if (event == ODROID_DIALOG_NEXT) {
-        if (weekday == max)
-            weekday = min;
-        else
-            weekday++;
-        GW_SetCurrentWeekday(weekday);
-    }
-
-    sprintf(option->value, "%s", (char *) GW_RTC_Weekday[weekday-1]);
+    sprintf(option->value, "%s", (char *) GW_RTC_Weekday[GW_GetCurrentWeekday() - 1]);
     return event == ODROID_DIALOG_ENTER;
 }
 
 bool month_update_cb(odroid_dialog_choice_t *option, odroid_dialog_event_t event, uint32_t repeat)
 {
-    int8_t month = GW_GetCurrentMonth();
-    int8_t min = 1;
-    int8_t max = 12;
-
     if (event == ODROID_DIALOG_PREV) {
-        if (month == min)
-            month = max;
-        else
-            month--;
-        GW_SetCurrentMonth(month);
+        GW_AddToCurrentMonth(-1);
     }
     else if (event == ODROID_DIALOG_NEXT) {
-        if (month == max)
-            month = min;
-        else
-            month++;
-        GW_SetCurrentMonth(month);
+        GW_AddToCurrentMonth(1);
     }
 
-    sprintf(option->value, "%02d", month);
+    sprintf(option->value, "%02d", GW_GetCurrentMonth());
     return event == ODROID_DIALOG_ENTER;
 }
 
 bool year_update_cb(odroid_dialog_choice_t *option, odroid_dialog_event_t event, uint32_t repeat)
 {
-    int8_t year = GW_GetCurrentYear();
-    int8_t min = 0;
-    int8_t max = 99;
-
     if (event == ODROID_DIALOG_PREV) {
-        if (year == min)
-            year = max;
-        else
-            year--;
-        GW_SetCurrentYear(year);
+        GW_AddToCurrentYear(-1);
     }
     else if (event == ODROID_DIALOG_NEXT) {
-        if (year == max)
-            year = min;
-        else
-            year++;
-        GW_SetCurrentYear(year);
+        GW_AddToCurrentYear(1);
     }
 
-    sprintf(option->value, "20%02d", year);
+    sprintf(option->value, "20%02d", GW_GetCurrentYear());
     return event == ODROID_DIALOG_ENTER;
 
 }
 
 bool time_display_cb(odroid_dialog_choice_t *option, odroid_dialog_event_t event, uint32_t repeat)
 {
-    HAL_RTC_GetTime(&hrtc, &GW_currentTime, RTC_FORMAT_BIN);
-    HAL_RTC_GetDate(&hrtc, &GW_currentDate, RTC_FORMAT_BIN);
-
-    curr_lang->fmtTime(option->value, curr_lang->s_Time_Format, GW_currentTime.Hours, GW_currentTime.Minutes, GW_currentTime.Seconds);
+    curr_lang->fmtTime(option->value, curr_lang->s_Time_Format, GW_GetCurrentHour(), GW_GetCurrentMinute(), GW_GetCurrentSecond());
     return event == ODROID_DIALOG_ENTER;
 }
 
 bool date_display_cb(odroid_dialog_choice_t *option, odroid_dialog_event_t event, uint32_t repeat)
 {
     const char * GW_RTC_Weekday[] = {curr_lang->s_Weekday_Mon, curr_lang->s_Weekday_Tue, curr_lang->s_Weekday_Wed, curr_lang->s_Weekday_Thu, curr_lang->s_Weekday_Fri, curr_lang->s_Weekday_Sat, curr_lang->s_Weekday_Sun};
-    HAL_RTC_GetTime(&hrtc, &GW_currentTime, RTC_FORMAT_BIN);
-    HAL_RTC_GetDate(&hrtc, &GW_currentDate, RTC_FORMAT_BIN);
-
-    curr_lang->fmtDate(option->value, curr_lang->s_Date_Format, GW_currentDate.Date, GW_currentDate.Month, GW_currentDate.Year, (char *) GW_RTC_Weekday[GW_currentDate.WeekDay-1]);
+    curr_lang->fmtDate(option->value, curr_lang->s_Date_Format, GW_GetCurrentDay(), GW_GetCurrentMonth(), GW_GetCurrentYear(), (char *) GW_RTC_Weekday[GW_GetCurrentWeekday() - 1]);
     return event == ODROID_DIALOG_ENTER;
 }
 
@@ -747,15 +649,14 @@ void retro_loop()
 
                     // Date setup
                     odroid_dialog_choice_t dateoptions[8] = {
-                        {0, curr_lang->s_Day, day_value, 1, &day_update_cb},
-                        {1, curr_lang->s_Month, month_value, 1, &month_update_cb},
                         {2, curr_lang->s_Year, year_value, 1, &year_update_cb},
-                        {3, curr_lang->s_Weekday, weekday_value, 1, &weekday_update_cb},
+                        {1, curr_lang->s_Month, month_value, 1, &month_update_cb},
+                        {0, curr_lang->s_Day, day_value, 1, &day_update_cb},
+                        {-1, curr_lang->s_Weekday, weekday_value, 0, &weekday_update_cb},
                         ODROID_DIALOG_CHOICE_LAST};
                     sel = odroid_overlay_dialog(curr_lang->s_Date_setup, dateoptions, 0);
                 }
 
-                (void)sel;
                 gui_redraw();
             }
             else if (last_key == key_up)

--- a/Core/Src/retro-go/rg_main.c
+++ b/Core/Src/retro-go/rg_main.c
@@ -486,6 +486,7 @@ void retro_loop()
                     {-1, curr_lang->s_Author_, "Sylver Bruneau", 0, NULL},
                     {-1, curr_lang->s_Author_, "bzhxx", 0, NULL},
                     {-1, curr_lang->s_UI_Mod, "orzeus", 0, NULL},
+                    {-1, curr_lang->s_Author_, "Benjamin S\xf8lberg", 0, NULL},
                     ODROID_DIALOG_CHOICE_SEPARATOR,
                     {-1, curr_lang->s_Lang, curr_lang->s_LangAuthor, 0, NULL},
                     ODROID_DIALOG_CHOICE_SEPARATOR,

--- a/Core/Src/retro-go/rg_main.c
+++ b/Core/Src/retro-go/rg_main.c
@@ -138,7 +138,7 @@ static bool main_menu_cpu_oc_cb(odroid_dialog_choice_t *option, odroid_dialog_ev
 }
 
 static bool main_menu_timeout_cb(odroid_dialog_choice_t *option, odroid_dialog_event_t event, uint32_t repeat)
-{ //TODO: Old timeouts should be rounded down to minutes.
+{
     const int TIMEOUT_STEP = 60;
     const int TIMEOUT_MIN = 0;
     const int TIMEOUT_MAX = 3600;

--- a/Core/Src/retro-go/rg_main.c
+++ b/Core/Src/retro-go/rg_main.c
@@ -265,6 +265,203 @@ static bool lang_update_cb(odroid_dialog_choice_t *option, odroid_dialog_event_t
     return event == ODROID_DIALOG_ENTER;
 }
 
+bool hour_update_cb(odroid_dialog_choice_t *option, odroid_dialog_event_t event, uint32_t repeat)
+{
+    int8_t hour = GW_GetCurrentHour();
+    int8_t min = 0;
+    int8_t max = 23;
+
+    if (event == ODROID_DIALOG_PREV) {
+        if (hour == min)
+            hour = max;
+        else
+            hour--;
+        GW_SetCurrentHour(hour);
+    }
+    else if (event == ODROID_DIALOG_NEXT) {
+        if (hour == max)
+            hour = min;
+        else
+            hour++;
+        GW_SetCurrentHour(hour);
+    }
+
+    sprintf(option->value, "%02d", hour);
+    return event == ODROID_DIALOG_ENTER;
+}
+
+bool minute_update_cb(odroid_dialog_choice_t *option, odroid_dialog_event_t event, uint32_t repeat)
+{
+    int8_t minute = GW_GetCurrentMinute();
+    int8_t min = 0;
+    int8_t max = 59;
+
+    if (event == ODROID_DIALOG_PREV) {
+        if (minute == min)
+            minute = max;
+        else
+            minute--;
+        GW_SetCurrentMinute(minute);
+    }
+    else if (event == ODROID_DIALOG_NEXT) {
+        if (minute == max)
+            minute = min;
+        else
+            minute++;
+        GW_SetCurrentMinute(minute);
+    }
+
+    sprintf(option->value, "%02d", minute);
+    return event == ODROID_DIALOG_ENTER;
+}
+
+bool second_update_cb(odroid_dialog_choice_t *option, odroid_dialog_event_t event, uint32_t repeat)
+{
+    int8_t second = GW_GetCurrentSecond();
+    int8_t min = 0;
+    int8_t max = 59;
+
+    if (event == ODROID_DIALOG_PREV) {
+        if (second == min)
+            second = max;
+        else
+            second--;
+        GW_SetCurrentSecond(second);
+    }
+    else if (event == ODROID_DIALOG_NEXT) {
+        if (second == max)
+            second = min;
+        else
+            second++;
+        GW_SetCurrentSecond(second);
+    }
+
+    sprintf(option->value, "%02d", second);
+    return event == ODROID_DIALOG_ENTER;
+}
+
+bool day_update_cb(odroid_dialog_choice_t *option, odroid_dialog_event_t event, uint32_t repeat)
+{
+    int8_t day = GW_GetCurrentDay();
+    int8_t min = 1;
+    int8_t max = 31;
+
+    if (event == ODROID_DIALOG_PREV) {
+        if (day == min)
+            day = max;
+        else
+            day--;
+        GW_SetCurrentDay(day);
+    }
+    else if (event == ODROID_DIALOG_NEXT) {
+        if (day == max)
+            day = min;
+        else
+            day++;
+        GW_SetCurrentDay(day);
+    }
+
+    sprintf(option->value, "%02d", day);
+    return event == ODROID_DIALOG_ENTER;
+}
+
+bool weekday_update_cb(odroid_dialog_choice_t *option, odroid_dialog_event_t event, uint32_t repeat)
+{
+    const char * GW_RTC_Weekday[] = {curr_lang->s_Weekday_Mon, curr_lang->s_Weekday_Tue, curr_lang->s_Weekday_Wed, curr_lang->s_Weekday_Thu, curr_lang->s_Weekday_Fri, curr_lang->s_Weekday_Sat, curr_lang->s_Weekday_Sun};
+
+    int8_t weekday = GW_GetCurrentWeekday();
+    int8_t min = 1;
+    int8_t max = 7;
+
+    if (event == ODROID_DIALOG_PREV) {
+        if (weekday == min)
+            weekday = max;
+        else
+            weekday--;
+        GW_SetCurrentWeekday(weekday);
+    }
+    else if (event == ODROID_DIALOG_NEXT) {
+        if (weekday == max)
+            weekday = min;
+        else
+            weekday++;
+        GW_SetCurrentWeekday(weekday);
+    }
+
+    sprintf(option->value, "%s", (char *) GW_RTC_Weekday[weekday-1]);
+    return event == ODROID_DIALOG_ENTER;
+}
+
+bool month_update_cb(odroid_dialog_choice_t *option, odroid_dialog_event_t event, uint32_t repeat)
+{
+    int8_t month = GW_GetCurrentMonth();
+    int8_t min = 1;
+    int8_t max = 12;
+
+    if (event == ODROID_DIALOG_PREV) {
+        if (month == min)
+            month = max;
+        else
+            month--;
+        GW_SetCurrentMonth(month);
+    }
+    else if (event == ODROID_DIALOG_NEXT) {
+        if (month == max)
+            month = min;
+        else
+            month++;
+        GW_SetCurrentMonth(month);
+    }
+
+    sprintf(option->value, "%02d", month);
+    return event == ODROID_DIALOG_ENTER;
+}
+
+bool year_update_cb(odroid_dialog_choice_t *option, odroid_dialog_event_t event, uint32_t repeat)
+{
+    int8_t year = GW_GetCurrentYear();
+    int8_t min = 0;
+    int8_t max = 99;
+
+    if (event == ODROID_DIALOG_PREV) {
+        if (year == min)
+            year = max;
+        else
+            year--;
+        GW_SetCurrentYear(year);
+    }
+    else if (event == ODROID_DIALOG_NEXT) {
+        if (year == max)
+            year = min;
+        else
+            year++;
+        GW_SetCurrentYear(year);
+    }
+
+    sprintf(option->value, "20%02d", year);
+    return event == ODROID_DIALOG_ENTER;
+
+}
+
+bool time_display_cb(odroid_dialog_choice_t *option, odroid_dialog_event_t event, uint32_t repeat)
+{
+    HAL_RTC_GetTime(&hrtc, &GW_currentTime, RTC_FORMAT_BIN);
+    HAL_RTC_GetDate(&hrtc, &GW_currentDate, RTC_FORMAT_BIN);
+
+    curr_lang->fmtTime(option->value, curr_lang->s_Time_Format, GW_currentTime.Hours, GW_currentTime.Minutes, GW_currentTime.Seconds);
+    return event == ODROID_DIALOG_ENTER;
+}
+
+bool date_display_cb(odroid_dialog_choice_t *option, odroid_dialog_event_t event, uint32_t repeat)
+{
+    const char * GW_RTC_Weekday[] = {curr_lang->s_Weekday_Mon, curr_lang->s_Weekday_Tue, curr_lang->s_Weekday_Wed, curr_lang->s_Weekday_Thu, curr_lang->s_Weekday_Fri, curr_lang->s_Weekday_Sat, curr_lang->s_Weekday_Sun};
+    HAL_RTC_GetTime(&hrtc, &GW_currentTime, RTC_FORMAT_BIN);
+    HAL_RTC_GetDate(&hrtc, &GW_currentDate, RTC_FORMAT_BIN);
+
+    curr_lang->fmtDate(option->value, curr_lang->s_Date_Format, GW_currentDate.Date, GW_currentDate.Month, GW_currentDate.Year, (char *) GW_RTC_Weekday[GW_currentDate.WeekDay-1]);
+    return event == ODROID_DIALOG_ENTER;
+}
+
 static inline bool tab_enabled(tab_t *tab)
 {
     int disabled_tabs = 0;

--- a/Core/Src/retro-go/rg_rtc.c
+++ b/Core/Src/retro-go/rg_rtc.c
@@ -1,200 +1,248 @@
-#include "main.h"
-#include "rg_rtc.h"
-#include "rg_i18n.h"
-#include "stm32h7xx_hal.h"
+#include <string.h>
 #include <time.h>
 
+#include "main.h"
+#include "rg_rtc.h"
+#include "stm32h7xx_hal.h"
 
-RTC_TimeTypeDef GW_currentTime = {0};
-RTC_DateTypeDef GW_currentDate = {0};
+const uint8_t MIN_TM_YEAR = 100; // 2000
+const uint8_t MAX_TM_YEAR = 199; // 2099
+const uint8_t MIN_TM_MON = 0;
+const uint8_t MAX_TM_MON = 11;
+const uint8_t MIN_TM_DAY = 1;
+const uint8_t MAX_TM_DAY = 31;
+const uint8_t MAX_TM_WEEKDAY = 6;
+const uint8_t MIN_TM_HOUR = 0;
+const uint8_t MAX_TM_HOUR = 23;
+const uint8_t MIN_TM_MIN = 0;
+const uint8_t MAX_TM_MIN = 59;
+const uint8_t MIN_TM_SEC = 0;
+const uint8_t MAX_TM_SEC = 59;
+const uint8_t MIN_RTC_MONTH = 1;   // tm month is 0 based while RTC is 1 based
+const uint8_t MIN_RTC_WEEKDAY = 1; // tm month is 0 and sunday based while RTC is 1 and monday based
+const uint8_t MAX_RTC_WEEKDAY = 7;
+
+struct tm TM;
+uint32_t subSecond = 0;
+
+void ReadRTC() {
+    RTC_TimeTypeDef GW_currentTime = {0};
+    RTC_DateTypeDef GW_currentDate = {0};
+
+    // Get date & time. According to STM docs, both functions need to be called at once.
+    HAL_RTC_GetTime(&hrtc, &GW_currentTime, RTC_FORMAT_BIN);
+    HAL_RTC_GetDate(&hrtc, &GW_currentDate, RTC_FORMAT_BIN);
+
+    TM.tm_year = GW_currentDate.Year + MIN_TM_YEAR; // tm_year base is 1900, RTC can only save 0 - 99, so bump to 2000.
+    TM.tm_mon = GW_currentDate.Month - MIN_RTC_MONTH;
+    TM.tm_mday = GW_currentDate.Date;
+
+    TM.tm_hour = GW_currentTime.Hours;
+    TM.tm_min = GW_currentTime.Minutes;
+    TM.tm_sec = GW_currentTime.Seconds;
+    subSecond = GW_currentTime.SubSeconds;
+
+    // We make a lenient conversion of the RTC datetime as it can't really be trusted on the G&W if the original set datetime was invalid.
+    // This also has the side effect of setting the correct "day of week".
+    time_t clock = mktime(&TM);
+    localtime_r(&clock, &TM);
+}
+
+void UpdateRTC() {
+    RTC_TimeTypeDef GW_currentTime = {0};
+    RTC_DateTypeDef GW_currentDate = {0};
+
+    // Get date & time. According to STM docs, both functions need to be called at once before updating
+    HAL_RTC_GetTime(&hrtc, &GW_currentTime, RTC_FORMAT_BIN);
+    HAL_RTC_GetDate(&hrtc, &GW_currentDate, RTC_FORMAT_BIN);
+
+    GW_currentDate.Year = TM.tm_year - MIN_TM_YEAR;
+    GW_currentDate.Month = TM.tm_mon + MIN_RTC_MONTH;
+    GW_currentDate.Date = TM.tm_mday;
+    GW_currentDate.WeekDay = TM.tm_wday;
+
+    GW_currentTime.Hours = TM.tm_hour;
+    GW_currentTime.Minutes = TM.tm_min;
+    GW_currentTime.Seconds = TM.tm_sec;
+
+    if (HAL_RTC_SetDate(&hrtc, &GW_currentDate, RTC_FORMAT_BIN) != HAL_OK || HAL_RTC_SetTime(&hrtc, &GW_currentTime, RTC_FORMAT_BIN) != HAL_OK) {
+        Error_Handler();
+    }
+
+    ReadRTC(); // Should really not be necessary, but we want to ensure that the RTC is the master
+}
+
+uint8_t GetMaxDayOfCurrentMonth(void) {
+    // Brute force
+    for (int i = MAX_TM_DAY; i >= MIN_TM_DAY; i--) {
+        struct tm tm = TM; // Clone
+        tm.tm_mday = i;
+        mktime(&tm);
+        if (tm.tm_mday == i) {
+            return i;
+        }
+    }
+
+    // Never going to happen
+    Error_Handler();
+    return 0;
+}
 
 // Getters
 uint8_t GW_GetCurrentHour(void) {
+    ReadRTC();
 
-    // Get time. According to STM docs, both functions need to be called at once.
-    HAL_RTC_GetTime(&hrtc, &GW_currentTime, RTC_FORMAT_BIN);
-    HAL_RTC_GetDate(&hrtc, &GW_currentDate, RTC_FORMAT_BIN);
-
-    return GW_currentTime.Hours;
-
+    return TM.tm_hour;
 }
 
 uint8_t GW_GetCurrentMinute(void) {
+    ReadRTC();
 
-    // Get time. According to STM docs, both functions need to be called at once.
-    HAL_RTC_GetTime(&hrtc, &GW_currentTime, RTC_FORMAT_BIN);
-    HAL_RTC_GetDate(&hrtc, &GW_currentDate, RTC_FORMAT_BIN);
-
-    return GW_currentTime.Minutes;
+    return TM.tm_min;
 }
 
 uint8_t GW_GetCurrentSecond(void) {
+    ReadRTC();
 
-    // Get time. According to STM docs, both functions need to be called at once.
-    HAL_RTC_GetTime(&hrtc, &GW_currentTime, RTC_FORMAT_BIN);
-    HAL_RTC_GetDate(&hrtc, &GW_currentDate, RTC_FORMAT_BIN);
+    return TM.tm_sec;
+}
 
-    return GW_currentTime.Seconds;
+uint32_t GW_GetCurrentSubSeconds(void) {
+    ReadRTC();
+
+    return subSecond;
 }
 
 uint8_t GW_GetCurrentMonth(void) {
+    ReadRTC();
 
-    // Get time. According to STM docs, both functions need to be called at once.
-    HAL_RTC_GetTime(&hrtc, &GW_currentTime, RTC_FORMAT_BIN);
-    HAL_RTC_GetDate(&hrtc, &GW_currentDate, RTC_FORMAT_BIN);
-
-    return GW_currentDate.Month;
+    return TM.tm_mon + MIN_RTC_MONTH; // Compatible with RTC layout (jan = 1, dec = 12)
 }
 
 uint8_t GW_GetCurrentDay(void) {
+    ReadRTC();
 
-    // Get time. According to STM docs, both functions need to be called at once.
-    HAL_RTC_GetTime(&hrtc, &GW_currentTime, RTC_FORMAT_BIN);
-    HAL_RTC_GetDate(&hrtc, &GW_currentDate, RTC_FORMAT_BIN);
-
-    return GW_currentDate.Date;
+    return TM.tm_mday;
 }
 
 uint8_t GW_GetCurrentWeekday(void) {
+    ReadRTC();
 
-    // Get time. According to STM docs, both functions need to be called at once.
-    HAL_RTC_GetTime(&hrtc, &GW_currentTime, RTC_FORMAT_BIN);
-    HAL_RTC_GetDate(&hrtc, &GW_currentDate, RTC_FORMAT_BIN);
-
-    return GW_currentDate.WeekDay;
+    return ((TM.tm_wday + MAX_TM_WEEKDAY) % MAX_RTC_WEEKDAY) + MIN_RTC_WEEKDAY; // Compatible with RTC layout (monday = 1, Sunday = 7)
 }
 
 uint8_t GW_GetCurrentYear(void) {
+    ReadRTC();
 
-    // Get time. According to STM docs, both functions need to be called at once.
-    HAL_RTC_GetTime(&hrtc, &GW_currentTime, RTC_FORMAT_BIN);
-    HAL_RTC_GetDate(&hrtc, &GW_currentDate, RTC_FORMAT_BIN);
-
-    return GW_currentDate.Year;
+    return TM.tm_year - MIN_TM_YEAR;
 }
 
 // Setters
-void GW_SetCurrentHour(const uint8_t hour) {
+void GW_AddToCurrentHour(const int8_t direction) {
+    ReadRTC();
 
-    // Update time before we can set it
-    HAL_RTC_GetTime(&hrtc, &GW_currentTime, RTC_FORMAT_BIN);
-    HAL_RTC_GetDate(&hrtc, &GW_currentDate, RTC_FORMAT_BIN);
+    TM.tm_hour += direction;
+    if (TM.tm_hour > MAX_TM_HOUR) {
+        TM.tm_hour = MIN_TM_HOUR;
+    } else if (TM.tm_hour < MIN_TM_HOUR) {
+        TM.tm_hour = MAX_TM_HOUR;
+    }
 
-    // Set time
-    GW_currentTime.Hours = hour;
-    if (HAL_RTC_SetTime(&hrtc, &GW_currentTime, RTC_FORMAT_BIN) != HAL_OK)
-    {
-        Error_Handler();
+    UpdateRTC();
+}
+
+void GW_AddToCurrentMinute(const int8_t direction) {
+    ReadRTC();
+
+    TM.tm_min += direction;
+    if (TM.tm_min > MAX_TM_MIN) {
+        TM.tm_min = MIN_TM_MIN;
+    } else if (TM.tm_min < MIN_TM_MIN) {
+        TM.tm_min = MAX_TM_MIN;
+    }
+
+    UpdateRTC();
+}
+
+void GW_AddToCurrentSecond(const int8_t direction) {
+    ReadRTC();
+
+    TM.tm_sec += direction;
+    if (TM.tm_sec > MAX_TM_SEC) {
+        TM.tm_sec = MIN_TM_SEC;
+    } else if (TM.tm_sec < MIN_TM_SEC) {
+        TM.tm_sec = MAX_TM_SEC;
+    }
+
+    UpdateRTC();
+}
+
+void GW_AddToCurrentMonth(const int8_t direction) {
+    ReadRTC();
+
+    uint8_t mday = TM.tm_mday;
+
+    TM.tm_mon += direction;
+    if (TM.tm_mon > MAX_TM_MON) {
+        TM.tm_mon = MIN_TM_MON;
+    } else if (TM.tm_mon < MIN_TM_MON) {
+        TM.tm_mon = MAX_TM_MON;
+    }
+
+    UpdateRTC();
+
+    // Fixup from long to short month transition like 2000-01-31 -> 2000-02-29 or 2000-05-31 -> 2000-04-30
+    if (TM.tm_mday != mday) {
+        TM.tm_mon--;
+        TM.tm_mday = GetMaxDayOfCurrentMonth();
+
+        UpdateRTC();
     }
 }
 
-void GW_SetCurrentMinute(const uint8_t minute) {
+void GW_AddToCurrentDay(const int8_t direction) {
+    ReadRTC();
 
-    // Update time before we can set it
-    HAL_RTC_GetTime(&hrtc, &GW_currentTime, RTC_FORMAT_BIN);
-    HAL_RTC_GetDate(&hrtc, &GW_currentDate, RTC_FORMAT_BIN);
-
-    // Set time
-    GW_currentTime.Minutes = minute;
-    if (HAL_RTC_SetTime(&hrtc, &GW_currentTime, RTC_FORMAT_BIN) != HAL_OK)
-    {
-        Error_Handler();
+    uint8_t maxDay = GetMaxDayOfCurrentMonth();
+    TM.tm_mday += direction;
+    if (TM.tm_mday > maxDay) {
+        TM.tm_mday = MIN_TM_DAY;
+    } else if (TM.tm_mday < MIN_TM_DAY) {
+        TM.tm_mday = maxDay;
     }
+
+    UpdateRTC();
 }
 
-void GW_SetCurrentSecond(const uint8_t second) {
+void GW_AddToCurrentYear(const int8_t direction) {
+    ReadRTC();
 
-    // Update time before we can set it
-    HAL_RTC_GetTime(&hrtc, &GW_currentTime, RTC_FORMAT_BIN);
-    HAL_RTC_GetDate(&hrtc, &GW_currentDate, RTC_FORMAT_BIN);
-
-    // Set time
-    GW_currentTime.Seconds = second;
-    if (HAL_RTC_SetTime(&hrtc, &GW_currentTime, RTC_FORMAT_BIN) != HAL_OK)
-    {
-        Error_Handler();
+    TM.tm_year += direction;
+    if (TM.tm_year > MAX_TM_YEAR) {
+        TM.tm_year = MIN_TM_YEAR;
+    } else if (TM.tm_year < MIN_TM_YEAR) {
+        TM.tm_year = MAX_TM_YEAR;
     }
+
+    UpdateRTC();
 }
 
-void GW_SetCurrentMonth(const uint8_t month) {
-
-    // Update time before we can set it
-    HAL_RTC_GetTime(&hrtc, &GW_currentTime, RTC_FORMAT_BIN);
-    HAL_RTC_GetDate(&hrtc, &GW_currentDate, RTC_FORMAT_BIN);
-
-    // Set date
-    GW_currentDate.Month = month;
-
-    if (HAL_RTC_SetDate(&hrtc, &GW_currentDate, RTC_FORMAT_BIN) != HAL_OK)
-    {
-        Error_Handler();
-    }
-}
-
-void GW_SetCurrentDay(const uint8_t day) {
-
-    // Update time before we can set it
-    HAL_RTC_GetTime(&hrtc, &GW_currentTime, RTC_FORMAT_BIN);
-    HAL_RTC_GetDate(&hrtc, &GW_currentDate, RTC_FORMAT_BIN);
-
-    // Set date
-    GW_currentDate.Date = day;
-
-    if (HAL_RTC_SetDate(&hrtc, &GW_currentDate, RTC_FORMAT_BIN) != HAL_OK)
-    {
-        Error_Handler();
-    }
-}
-
-void GW_SetCurrentWeekday(const uint8_t weekday) {
-
-    // Update time before we can set it
-    HAL_RTC_GetTime(&hrtc, &GW_currentTime, RTC_FORMAT_BIN);
-    HAL_RTC_GetDate(&hrtc, &GW_currentDate, RTC_FORMAT_BIN);
-
-    // Set date
-    GW_currentDate.WeekDay = weekday;
-
-    if (HAL_RTC_SetDate(&hrtc, &GW_currentDate, RTC_FORMAT_BIN) != HAL_OK)
-    {
-        Error_Handler();
-    }
-}
-
-void GW_SetCurrentYear(const uint8_t year) {
-
-    // Update time before we can set it
-    HAL_RTC_GetTime(&hrtc, &GW_currentTime, RTC_FORMAT_BIN);
-    HAL_RTC_GetDate(&hrtc, &GW_currentDate, RTC_FORMAT_BIN);
-
-    // Set date
-    GW_currentDate.Year = year;
-
-    if (HAL_RTC_SetDate(&hrtc, &GW_currentDate, RTC_FORMAT_BIN) != HAL_OK)
-    {
-        Error_Handler();
-    }
-}
-
+// Function to return Unix timestamp since 1st Jan 1970.
+// The time is returned as an 64-bit value, but only the top 32-bits are populated.
 time_t GW_GetUnixTime(void) {
-    // Function to return Unix timestamp since 1st Jan 1970.
-    // The time is returned as an 64-bit value, but only the top 32-bits are populated.
+    ReadRTC();
 
-    time_t timestamp;
-    struct tm timeStruct;
+    return mktime(&TM);
+}
 
-    HAL_RTC_GetTime(&hrtc, &GW_currentTime, RTC_FORMAT_BIN);
-    HAL_RTC_GetDate(&hrtc, &GW_currentDate, RTC_FORMAT_BIN);
+void GW_GetUnixTM(struct tm *tm) {
+    ReadRTC();
 
-    timeStruct.tm_year = GW_currentDate.Year + 100;  // tm_year base is 1900, RTC can only save 0 - 99, so bump to 2000.
-    timeStruct.tm_mday = GW_currentDate.Date;
-    timeStruct.tm_mon  = GW_currentDate.Month - 1;
+    *tm = TM; // Clone
+}
 
-    timeStruct.tm_hour = GW_currentTime.Hours;
-    timeStruct.tm_min  = GW_currentTime.Minutes;
-    timeStruct.tm_sec  = GW_currentTime.Seconds;
+void GW_SetUnixTM(struct tm *tm) {
+    TM = *tm; // Clone
 
-    timestamp = mktime(&timeStruct);
-
-    return timestamp;
+    UpdateRTC();
 }

--- a/Core/Src/retro-go/rg_rtc.c
+++ b/Core/Src/retro-go/rg_rtc.c
@@ -18,6 +18,7 @@ uint8_t GW_GetCurrentHour(void) {
     return GW_currentTime.Hours;
 
 }
+
 uint8_t GW_GetCurrentMinute(void) {
 
     // Get time. According to STM docs, both functions need to be called at once.
@@ -26,6 +27,7 @@ uint8_t GW_GetCurrentMinute(void) {
 
     return GW_currentTime.Minutes;
 }
+
 uint8_t GW_GetCurrentSecond(void) {
 
     // Get time. According to STM docs, both functions need to be called at once.
@@ -43,6 +45,7 @@ uint8_t GW_GetCurrentMonth(void) {
 
     return GW_currentDate.Month;
 }
+
 uint8_t GW_GetCurrentDay(void) {
 
     // Get time. According to STM docs, both functions need to be called at once.
@@ -60,6 +63,7 @@ uint8_t GW_GetCurrentWeekday(void) {
 
     return GW_currentDate.WeekDay;
 }
+
 uint8_t GW_GetCurrentYear(void) {
 
     // Get time. According to STM docs, both functions need to be called at once.
@@ -83,6 +87,7 @@ void GW_SetCurrentHour(const uint8_t hour) {
         Error_Handler();
     }
 }
+
 void GW_SetCurrentMinute(const uint8_t minute) {
 
     // Update time before we can set it
@@ -125,6 +130,7 @@ void GW_SetCurrentMonth(const uint8_t month) {
         Error_Handler();
     }
 }
+
 void GW_SetCurrentDay(const uint8_t day) {
 
     // Update time before we can set it
@@ -154,6 +160,7 @@ void GW_SetCurrentWeekday(const uint8_t weekday) {
         Error_Handler();
     }
 }
+
 void GW_SetCurrentYear(const uint8_t year) {
 
     // Update time before we can set it
@@ -169,143 +176,10 @@ void GW_SetCurrentYear(const uint8_t year) {
     }
 }
 
-// Callbacks for UI purposes
-bool hour_update_cb(odroid_dialog_choice_t *option, odroid_dialog_event_t event, uint32_t repeat) {
-
-    int8_t hour = GW_GetCurrentHour();
-    int8_t min = 0;
-    int8_t max = 23;
-
-    if (event == ODROID_DIALOG_PREV) {
-        if (hour == min)
-            hour = max;
-        else
-            hour--;
-        GW_SetCurrentHour(hour);
-    }
-    else if (event == ODROID_DIALOG_NEXT) {
-        if (hour == max)
-            hour = min;
-        else
-            hour++;
-        GW_SetCurrentHour(hour);
-    }
-
-    sprintf(option->value, "%02d", hour);
-    return event == ODROID_DIALOG_ENTER;
-    return false;
-
-}
-bool minute_update_cb(odroid_dialog_choice_t *option, odroid_dialog_event_t event, uint32_t repeat) { 
-    
-    int8_t minute = GW_GetCurrentMinute();
-    int8_t min = 0;
-    int8_t max = 59;
-
-    if (event == ODROID_DIALOG_PREV) {
-        if (minute == min)
-            minute = max;
-        else
-            minute--;
-        GW_SetCurrentMinute(minute);
-    }
-    else if (event == ODROID_DIALOG_NEXT) {
-        if (minute == max)
-            minute = min;
-        else
-            minute++;
-        GW_SetCurrentMinute(minute);
-    }
-
-    sprintf(option->value, "%02d", minute);
-    return event == ODROID_DIALOG_ENTER;
-    return false;
-
-}
-bool second_update_cb(odroid_dialog_choice_t *option, odroid_dialog_event_t event, uint32_t repeat) { 
-    
-    int8_t second = GW_GetCurrentSecond();
-    int8_t min = 0;
-    int8_t max = 59;
-
-    if (event == ODROID_DIALOG_PREV) {
-        if (second == min)
-            second = max;
-        else
-            second--;
-        GW_SetCurrentSecond(second);
-    }
-    else if (event == ODROID_DIALOG_NEXT) {
-        if (second == max)
-            second = min;
-        else
-            second++;
-        GW_SetCurrentSecond(second);
-    }
-
-    sprintf(option->value, "%02d", second);
-    return event == ODROID_DIALOG_ENTER;
-    return false;
-
-}
-
-bool month_update_cb(odroid_dialog_choice_t *option, odroid_dialog_event_t event, uint32_t repeat) { 
-        
-    int8_t month = GW_GetCurrentMonth();
-    int8_t min = 1;
-    int8_t max = 12;
-
-    if (event == ODROID_DIALOG_PREV) {
-        if (month == min)
-            month = max;
-        else
-            month--;
-        GW_SetCurrentMonth(month);
-    }
-    else if (event == ODROID_DIALOG_NEXT) {
-        if (month == max)
-            month = min;
-        else
-            month++;
-        GW_SetCurrentMonth(month);
-    }
-
-    sprintf(option->value, "%02d", month);
-    return event == ODROID_DIALOG_ENTER;
-    return false;
-    
-}
-bool day_update_cb(odroid_dialog_choice_t *option, odroid_dialog_event_t event, uint32_t repeat) { 
-        
-    int8_t day = GW_GetCurrentDay();
-    int8_t min = 1;
-    int8_t max = 31;
-
-    if (event == ODROID_DIALOG_PREV) {
-        if (day == min)
-            day = max;
-        else
-            day--;
-        GW_SetCurrentDay(day);
-    }
-    else if (event == ODROID_DIALOG_NEXT) {
-        if (day == max)
-            day = min;
-        else
-            day++;
-        GW_SetCurrentDay(day);
-    }
-
-    sprintf(option->value, "%02d", day);
-    return event == ODROID_DIALOG_ENTER;
-    return false;
-
-}
-
 time_t GW_GetUnixTime(void) {
     // Function to return Unix timestamp since 1st Jan 1970.
     // The time is returned as an 64-bit value, but only the top 32-bits are populated.
-    
+
     time_t timestamp;
     struct tm timeStruct;
 
@@ -323,78 +197,4 @@ time_t GW_GetUnixTime(void) {
     timestamp = mktime(&timeStruct);
 
     return timestamp;
-
-}
-
-bool weekday_update_cb(odroid_dialog_choice_t *option, odroid_dialog_event_t event, uint32_t repeat) { 
-    const char * GW_RTC_Weekday[] = {curr_lang->s_Weekday_Mon, curr_lang->s_Weekday_Tue, curr_lang->s_Weekday_Wed, curr_lang->s_Weekday_Thu, curr_lang->s_Weekday_Fri, curr_lang->s_Weekday_Sat, curr_lang->s_Weekday_Sun};
-                
-    int8_t weekday = GW_GetCurrentWeekday();
-    int8_t min = 1;
-    int8_t max = 7;
-
-    if (event == ODROID_DIALOG_PREV) {
-        if (weekday == min)
-            weekday = max;
-        else
-            weekday--;
-        GW_SetCurrentWeekday(weekday);
-    }
-    else if (event == ODROID_DIALOG_NEXT) {
-        if (weekday == max)
-            weekday = min;
-        else
-            weekday++;
-        GW_SetCurrentWeekday(weekday);
-    }
-
-    sprintf(option->value, "%s", (char *) GW_RTC_Weekday[weekday-1]);
-    return event == ODROID_DIALOG_ENTER;
-    return false;
-    
-}
-bool year_update_cb(odroid_dialog_choice_t *option, odroid_dialog_event_t event, uint32_t repeat) { 
-            
-    int8_t year = GW_GetCurrentYear();
-    int8_t min = 0;
-    int8_t max = 99;
-
-    if (event == ODROID_DIALOG_PREV) {
-        if (year == min)
-            year = max;
-        else
-            year--;
-        GW_SetCurrentYear(year);
-    }
-    else if (event == ODROID_DIALOG_NEXT) {
-        if (year == max)
-            year = min;
-        else
-            year++;
-        GW_SetCurrentYear(year);
-    }
-
-    sprintf(option->value, "20%02d", year);
-    return event == ODROID_DIALOG_ENTER;
-    return false;
-    
-}
-
-bool time_display_cb(odroid_dialog_choice_t *option, odroid_dialog_event_t event, uint32_t repeat) {
-    HAL_RTC_GetTime(&hrtc, &GW_currentTime, RTC_FORMAT_BIN);
-    HAL_RTC_GetDate(&hrtc, &GW_currentDate, RTC_FORMAT_BIN);
-
-    curr_lang->fmtTime(option->value, curr_lang->s_Time_Format, GW_currentTime.Hours, GW_currentTime.Minutes, GW_currentTime.Seconds);
-    return event == ODROID_DIALOG_ENTER;
-    return false;    
-}
-bool date_display_cb(odroid_dialog_choice_t *option, odroid_dialog_event_t event, uint32_t repeat) {
-
-    const char * GW_RTC_Weekday[] = {curr_lang->s_Weekday_Mon, curr_lang->s_Weekday_Tue, curr_lang->s_Weekday_Wed, curr_lang->s_Weekday_Thu, curr_lang->s_Weekday_Fri, curr_lang->s_Weekday_Sat, curr_lang->s_Weekday_Sun};
-    HAL_RTC_GetTime(&hrtc, &GW_currentTime, RTC_FORMAT_BIN);
-    HAL_RTC_GetDate(&hrtc, &GW_currentDate, RTC_FORMAT_BIN);
-    
-    curr_lang->fmtDate(option->value, curr_lang->s_Date_Format, GW_currentDate.Date, GW_currentDate.Month, GW_currentDate.Year, (char *) GW_RTC_Weekday[GW_currentDate.WeekDay-1]);
-    return event == ODROID_DIALOG_ENTER;
-    return false;
 }


### PR DESCRIPTION
TLDR: The RTC getting and setting date and time has been rewritten to encapsulate access to ensure correctness. This is especially important as the on-chip RTC really can't be trusted as it allows for setting wrong dates and weekday.

Commits has been split into "chunks by functionality" to ease the review process.

I have naturally tested it my self but I suggest a tester trying it out prior to accepting the PR to ensure audience acceptance.