### PR TITLE
Fixed all (8) warnings when compiling without COVERFLOW=1

### DIFF
--- a/Core/Src/porting/odroid_overlay.c
+++ b/Core/Src/porting/odroid_overlay.c
@@ -44,7 +44,9 @@ int odroid_overlay_game_menu()
 #include "rg_i18n.h"
 #include "main_msx.h"
 
+#if CHEAT_CODES == 1
 static retro_emulator_file_t *CHOSEN_FILE = NULL;
+#endif
 // static uint16_t *overlay_buffer = NULL;
 static uint16_t overlay_buffer[ODROID_SCREEN_WIDTH * 32 * 2] __attribute__((aligned(4)));
 static short dialog_open_depth = 0;

--- a/Core/Src/retro-go/gui.c
+++ b/Core/Src/retro-go/gui.c
@@ -43,6 +43,7 @@
 #define COVER_MAX_HEIGHT (100)
 #define COVER_MAX_WIDTH (186)
 
+
 #ifdef COVERFLOW
 /* instances for JPEG decoder */
 #include "hw_jpeg_decoder.h"
@@ -57,14 +58,16 @@
 
 static uint8_t *pJPEG_Buffer = NULL;
 static uint16_t *pCover_Buffer = NULL;
-static uint32_t current_cover_width = NOCOVER_WIDTH;
-static uint32_t current_cover_height = NOCOVER_HEIGHT;
-const static uint32_t COVER_BORDER = 6;
 
 const uint8_t cover_light[5] = {60, 120, 255, 120, 60};
 const uint8_t cover_light3[3] = {255, 120, 60};
 #endif
 
+#if COVERFLOW != 0
+const static uint32_t COVER_BORDER = 6;
+static uint32_t current_cover_width = NOCOVER_WIDTH;
+static uint32_t current_cover_height = NOCOVER_HEIGHT;
+#endif
 
 #if GNW_TARGET_ZELDA != 0
 //zelda version change mario red to zelda green

--- a/Core/Src/retro-go/rg_emulators.c
+++ b/Core/Src/retro-go/rg_emulators.c
@@ -312,7 +312,9 @@ void emulator_show_file_info(retro_emulator_file_t *file)
     char filename_value[128];
     char type_value[32];
     char size_value[32];
+#if COVERFLOW != 0
     char img_size[32];
+#endif
     //char crc_value[32];
     //crc_value[0] = '\x00';
 

--- a/Core/Src/retro-go/rg_main.c
+++ b/Core/Src/retro-go/rg_main.c
@@ -361,13 +361,12 @@ void retro_loop()
                 if (gui.joystick.values[i])
                     last_key = i;
 
-            int hori_view = false;
             int key_up = ODROID_INPUT_UP;
             int key_down = ODROID_INPUT_DOWN;
             int key_left = ODROID_INPUT_LEFT;
             int key_right = ODROID_INPUT_RIGHT;
 #if COVERFLOW != 0
-            hori_view = odroid_settings_theme_get();
+            int hori_view = odroid_settings_theme_get();
             if ((hori_view== 2) | (hori_view==3))
             {
                 key_up = ODROID_INPUT_LEFT;
@@ -480,7 +479,9 @@ void retro_loop()
             {
                 char font_value[16];
                 char timeout_value[16];
+#if COVERFLOW != 0
                 char theme_value[16];
+#endif
                 char colors_value[16];
                 char lang_value[64];
                 char ov_value[64];
@@ -502,10 +503,12 @@ void retro_loop()
                     //{9, curr_lang->s_Reboot, curr_lang->s_Original_system, 1, NULL},
 #endif
                     ODROID_DIALOG_CHOICE_LAST};
-                int r = odroid_overlay_settings_menu(choices);
 #if INTFLASH_BANK == 2
+                int r = odroid_overlay_settings_menu(choices);
                 if (r == 9)
                     soft_reset_do();
+#else
+                odroid_overlay_settings_menu(choices);
 #endif
                 if (oc_level_gets() != oc_level_get())
                     //reboot;


### PR DESCRIPTION
All warnings has been fixed while compiling without coverflow support.