### PR TITLE
Added support for live background updates while showing a dialog box

### DIFF
--- a/Core/Inc/retro-go/gui.h
+++ b/Core/Inc/retro-go/gui.h
@@ -90,6 +90,7 @@ void gui_resize_list(tab_t *tab, int new_size);
 listbox_item_t *gui_get_selected_item(tab_t *tab);
 
 void gui_event(gui_event_t event, tab_t *tab);
+void gui_redraw_callback(void);
 void gui_redraw(void);
 void gui_draw_header(tab_t *tab);
 void gui_draw_status(tab_t *tab);

--- a/Core/Src/porting/odroid_overlay.c
+++ b/Core/Src/porting/odroid_overlay.c
@@ -365,15 +365,11 @@ void odroid_overlay_darken_all()
                 dst_img[y * ODROID_SCREEN_WIDTH + x] = get_darken_pixel(dst_img[y * ODROID_SCREEN_WIDTH + x], 40);
 
         dst_img[0] = mgic;
-        lcd_sync();
     }
 }
 
 void odroid_overlay_draw_dialog(const char *header, odroid_dialog_choice_t *options, int sel)
 {
-
-    odroid_overlay_darken_all();
-
     int row_margin = 1;
     int row_height = i18n_get_text_height() + row_margin * 2;
     int box_width = 64;
@@ -674,7 +670,7 @@ int odroid_overlay_dialog_find_next_item(odroid_dialog_choice_t *options, int si
     return selected_index;
 }
 
-int odroid_overlay_dialog(const char *header, odroid_dialog_choice_t *options, int selected)
+int odroid_overlay_dialog_live(const char *header, odroid_dialog_choice_t *options, int selected, repaint_callback_t callback)
 {
     int options_count = get_dialog_items_count(options);
     int sel = odroid_overlay_dialog_find_next_item(options, options_count, selected < 0 ? (options_count + selected) : selected, 0);
@@ -686,6 +682,8 @@ int odroid_overlay_dialog(const char *header, odroid_dialog_choice_t *options, i
     lcd_sync();
     lcd_swap();
     HAL_Delay(20);
+    odroid_overlay_darken_all();
+    lcd_sync();
     odroid_overlay_draw_dialog(header, options, sel);
     dialog_open_depth++;
 
@@ -788,7 +786,18 @@ int odroid_overlay_dialog(const char *header, odroid_dialog_choice_t *options, i
             }
         }
 
+        if (callback != NULL)
+        {
+            callback();
+            dialog_open_depth--;
+        }
+        odroid_overlay_darken_all();
         odroid_overlay_draw_dialog(header, options, sel);
+        if (callback != NULL)
+        {
+            dialog_open_depth++;
+        }
+
         lcd_swap();
         HAL_Delay(20);
     }
@@ -800,6 +809,11 @@ int odroid_overlay_dialog(const char *header, odroid_dialog_choice_t *options, i
     dialog_open_depth--;
 
     return sel < 0 ? sel : options[sel].id;
+}
+
+int odroid_overlay_dialog(const char *header, odroid_dialog_choice_t *options, int selected)
+{
+    return odroid_overlay_dialog_live(header, options, selected, NULL);
 }
 
 int odroid_overlay_confirm(const char *text, bool yes_selected)
@@ -999,7 +1013,7 @@ static bool turbo_buttons_update_cb(odroid_dialog_choice_t *option, odroid_dialo
     return event == ODROID_DIALOG_ENTER;
 }
 
-int odroid_overlay_settings_menu(odroid_dialog_choice_t *extra_options)
+int odroid_overlay_settings_menu_live(odroid_dialog_choice_t *extra_options, repaint_callback_t callback)
 {
     static char bright_value[25];
     static char volume_value[25];
@@ -1020,11 +1034,16 @@ int odroid_overlay_settings_menu(odroid_dialog_choice_t *extra_options)
         memcpy(&options[options_count], extra_options, (extra_options_count + 1) * sizeof(odroid_dialog_choice_t));
     }
 
-    int ret = odroid_overlay_dialog(curr_lang->s_OptionsTit, options, 0);
+    int ret = odroid_overlay_dialog_live(curr_lang->s_OptionsTit, options, 0, callback);
 
     odroid_settings_commit();
 
     return ret;
+}
+
+int odroid_overlay_settings_menu(odroid_dialog_choice_t *extra_options)
+{
+    return odroid_overlay_settings_menu_live(extra_options, NULL);
 }
 
 static void draw_game_status_bar(runtime_stats_t stats)

--- a/Core/Src/retro-go/gui.c
+++ b/Core/Src/retro-go/gui.c
@@ -312,12 +312,17 @@ void gui_scroll_list(tab_t *tab, scroll_mode_t mode)
     }
 }
 
-void gui_redraw()
+void gui_redraw_callback()
 {
     tab_t *tab = gui_get_current_tab();
     gui_draw_header(tab);
     gui_draw_status(tab);
     gui_draw_list(tab);
+}
+
+void gui_redraw()
+{
+    gui_redraw_callback();
 
     lcd_swap();
 }

--- a/Core/Src/retro-go/rg_emulators.c
+++ b/Core/Src/retro-go/rg_emulators.c
@@ -335,7 +335,7 @@ void emulator_show_file_info(retro_emulator_file_t *file)
     sprintf(choices[3].value, "%d KB", file->img_size / 1024);
 	#endif
 
-    odroid_overlay_dialog(curr_lang->s_GameProp, choices, -1);
+    odroid_overlay_dialog_live(curr_lang->s_GameProp, choices, -1, &gui_redraw_callback);
 }
 
 #if CHEAT_CODES == 1
@@ -434,7 +434,7 @@ bool emulator_show_file_menu(retro_emulator_file_t *file)
 #endif
     }
 
-    int sel = odroid_overlay_dialog(file->name, choices, has_save ? 0 : 1);
+    int sel = odroid_overlay_dialog_live(file->name, choices, has_save ? 0 : 1, &gui_redraw_callback);
 
     if (sel == 0 || sel == 1) {
         gui_save_current_tab();

--- a/Core/Src/retro-go/rg_main.c
+++ b/Core/Src/retro-go/rg_main.c
@@ -396,7 +396,7 @@ void retro_loop()
                     {0, curr_lang->s_Close, "", 1, NULL},
                     ODROID_DIALOG_CHOICE_LAST};
 
-                int sel = odroid_overlay_dialog(curr_lang->s_Retro_Go, choices, -1);
+                int sel = odroid_overlay_dialog_live(curr_lang->s_Retro_Go, choices, -1, &gui_redraw_callback);
                 if (sel == 1)
                 {
                     // Reset settings
@@ -502,7 +502,7 @@ void retro_loop()
                     //{9, curr_lang->s_Reboot, curr_lang->s_Original_system, 1, NULL},
 #endif
                     ODROID_DIALOG_CHOICE_LAST};
-                int r = odroid_overlay_settings_menu(choices);
+                int r = odroid_overlay_settings_menu_live(choices, &gui_redraw_callback);
 #if INTFLASH_BANK == 2
                 if (r == 9)
                     soft_reset_do();
@@ -524,7 +524,7 @@ void retro_loop()
                     {0, curr_lang->s_Time, time_str, 1, &time_display_cb},
                     {1, curr_lang->s_Date, date_str, 1, &date_display_cb},
                     ODROID_DIALOG_CHOICE_LAST};
-                int sel = odroid_overlay_dialog(curr_lang->s_Time_Title, rtcinfo, 0);
+                int sel = odroid_overlay_dialog_live(curr_lang->s_Time_Title, rtcinfo, 0, &gui_redraw_callback);
 
                 if (sel == 0)
                 {


### PR DESCRIPTION
This has the benefit of updating both battery and clock status while displaying any of main dialog boxes. This also fixes a gui glitch when a dialog box changes its width while updating or displaying the date/time or when settings->font change.

The new API is still fully backwards compatible. And new functions can take a repaint callback for emulators to implement there own "live" backgrounds. It a bit like VMPaint event like on windows. 

This pull request needs https://github.com/sylverb/retro-go-stm32/pull/5

Here is a gif/video of the original glitch : https://gifyu.com/image/S43z9

And here is one showing that the glitch is gone and that the background is updated live : https://gifyu.com/image/S43zv
