### PR TITLE
Live background update and preview in all emulators

### DIFF
--- a/Core/Inc/gw_lcd.h
+++ b/Core/Inc/gw_lcd.h
@@ -28,12 +28,15 @@ void lcd_backlight_set(uint8_t brightness);
 void lcd_backlight_on();
 void lcd_backlight_off();
 void lcd_swap(void);
+void lcd_swap_with_wait(void);
 void lcd_sync(void);
+void lcd_clone(void);
 void* lcd_get_active_buffer(void);
 void* lcd_get_inactive_buffer(void);
 void lcd_set_buffers(uint16_t *buf1, uint16_t *buf2);
 void lcd_wait_for_vblank(void);
 uint32_t is_lcd_swap_pending(void);
+uint32_t lcd_wait_if_swap_pending(void);
 
 // To be used by fault handlers
 void lcd_reset_active_buffer(void);

--- a/Core/Inc/porting/common.h
+++ b/Core/Inc/porting/common.h
@@ -34,7 +34,7 @@ extern int16_t audiobuffer_dma[AUDIO_BUFFER_LENGTH * 2] __attribute__((section (
 extern const uint8_t volume_tbl[ODROID_AUDIO_VOLUME_MAX + 1];
 
 bool common_emu_frame_loop(void);
-void common_emu_input_loop(odroid_gamepad_state_t *joystick, odroid_dialog_choice_t *game_options);
+void common_emu_input_loop(odroid_gamepad_state_t *joystick, odroid_dialog_choice_t *game_options, void_callback_t repaint);
 
 typedef struct {
     uint last_busy;

--- a/Core/Src/porting/gb/main_gb.c
+++ b/Core/Src/porting/gb/main_gb.c
@@ -104,10 +104,6 @@ static inline void screen_blit_nn(int32_t dest_width, int32_t dest_height)
 #ifdef PROFILING_ENABLED
     printf("Blit: %d us\n", (1000000 * PROFILING_DIFF(t_blit)) / t_blit_t0.SecondFraction);
 #endif
-
-    common_ingame_overlay();
-
-    lcd_swap();
 }
 
 static void screen_blit_bilinear(int32_t dest_width)
@@ -169,10 +165,6 @@ static void screen_blit_bilinear(int32_t dest_width)
 #ifdef PROFILING_ENABLED
     printf("Blit: %d us\n", (1000000 * PROFILING_DIFF(t_blit)) / t_blit_t0.SecondFraction);
 #endif
-
-    common_ingame_overlay();
-
-    lcd_swap();
 }
 
 static inline void screen_blit_v3to5(void) {
@@ -231,10 +223,6 @@ static inline void screen_blit_v3to5(void) {
 #ifdef PROFILING_ENABLED
     printf("Blit: %d us\n", (1000000 * PROFILING_DIFF(t_blit)) / t_blit_t0.SecondFraction);
 #endif
-
-    common_ingame_overlay();
-
-    lcd_swap();
 }
 
 static inline void screen_blit_jth(void) {
@@ -311,10 +299,6 @@ static inline void screen_blit_jth(void) {
 #ifdef PROFILING_ENABLED
     printf("Blit: %d us\n", (1000000 * PROFILING_DIFF(t_blit)) / t_blit_t0.SecondFraction);
 #endif
-
-    common_ingame_overlay();
-
-    lcd_swap();
 }
 
 static void blit(void)
@@ -345,7 +329,6 @@ static void blit(void)
             assert(!"Unknown filtering mode");
         }
         break;
-        break;
     case ODROID_DISPLAY_SCALING_FULL:
         // full height, full width
         switch (filtering) {
@@ -375,6 +358,13 @@ static void blit(void)
         assert(!"Unknown scaling mode");
         break;
     }
+    common_ingame_overlay();
+}
+
+static void blit_and_swap(void)
+{
+    blit();
+    lcd_swap();
 }
 
 #define STATE_SAVE_BUFFER_LENGTH 1024 * 192
@@ -427,10 +417,6 @@ static bool palette_update_cb(odroid_dialog_choice_t *option, odroid_dialog_even
     if (event == ODROID_DIALOG_PREV || event == ODROID_DIALOG_NEXT) {
         odroid_settings_Palette_set(pal);
         pal_set_dmg(pal);
-        lcd_reset_active_buffer();
-        emu_run(true);
-        lcd_swap();
-        lcd_sync();
     }
 
     if (pal == 0) strcpy(option->value, "GBC");
@@ -554,7 +540,7 @@ rg_app_desc_t * init(uint8_t load_state, uint8_t save_slot)
     fb.pitch = update1.stride;
     fb.ptr = currentUpdate->buffer;
     fb.enabled = 1;
-    fb.blit_func = &blit;
+    fb.blit_func = &blit_and_swap;
 
     // Audio
     audiobuffer_emulator = ahb_calloc(sizeof(uint16_t),AUDIO_BUFFER_LENGTH_GB);
@@ -616,7 +602,7 @@ void app_main_gb(uint8_t load_state, uint8_t start_paused, uint8_t save_slot)
             // {301, "More...", "", 1, &advanced_settings_cb},
             ODROID_DIALOG_CHOICE_LAST
         };
-        common_emu_input_loop(&joystick, options);
+        common_emu_input_loop(&joystick, options, &blit);
 
         uint8_t turbo_buttons = odroid_settings_turbo_buttons_get();
         bool turbo_a = (joystick.values[ODROID_INPUT_A] && (turbo_buttons & 1));

--- a/Core/Src/porting/gw/main_gw.c
+++ b/Core/Src/porting/gw/main_gw.c
@@ -537,7 +537,13 @@ int app_main_gw(uint8_t load_state, uint8_t save_slot)
             softkey_alarm_pressed = 0;
         }
 
-        common_emu_input_loop(&joystick, options);
+        void _blit()
+        {
+            gw_system_blit(lcd_get_active_buffer());
+            common_ingame_overlay();
+        }
+
+        common_emu_input_loop(&joystick, options, &_blit);
 
         bool drawFrame = common_emu_frame_loop();
 
@@ -552,10 +558,9 @@ int app_main_gw(uint8_t load_state, uint8_t save_slot)
         /* update the screen only if there is no pending frame to render */
         if (!is_lcd_swap_pending() && drawFrame)
         {
-            gw_system_blit(lcd_get_active_buffer());
+            _blit();
             gw_debug_bar();
             if(debug_display_ram == 1) gw_display_ram_overlay();
-            common_ingame_overlay();
             lcd_swap();
 
             /* get how many cycles have been spent in graphics rendering */

--- a/Core/Src/porting/gwenesis/main_gwenesis.c
+++ b/Core/Src/porting/gwenesis/main_gwenesis.c
@@ -720,7 +720,27 @@ int app_main_gwenesis(uint8_t load_state, uint8_t start_paused, uint8_t save_slo
 
         ODROID_DIALOG_CHOICE_LAST};
 
-    common_emu_input_loop(&joystick, options);
+    hint_counter = gwenesis_vdp_regs[10];
+
+      screen_height = REG1_PAL ? 240 : 224;
+      screen_width = REG12_MODE_H40 ? 320 : 256;
+      lines_per_frame = REG1_PAL ? LINES_PER_FRAME_PAL : LINES_PER_FRAME_NTSC;
+      vert_screen_offset = REG1_PAL ? 0 : 320 * (240 - 224) / 2;
+
+      hori_screen_offset = 0; //REG12_MODE_H40 ? 0 : (320 - 256) / 2;
+
+    void _repaint()
+    {
+        screen = lcd_get_active_buffer();
+        gwenesis_vdp_set_buffer(&screen[vert_screen_offset + hori_screen_offset]);
+        for (int l = 0; l < lines_per_frame; l++)
+        {
+            gwenesis_vdp_render_line(l); /* render scan_line */
+        }
+        common_ingame_overlay();
+    }
+
+    common_emu_input_loop(&joystick, options, &_repaint);
 
      uint8_t turbo_buttons = odroid_settings_turbo_buttons_get();
      bool turbo_a = (joystick.values[ODROID_INPUT_A] && (turbo_buttons & 1));
@@ -735,14 +755,6 @@ int app_main_gwenesis(uint8_t load_state, uint8_t start_paused, uint8_t save_slo
     common_emu_frame_loop();
 
       /* Eumulator loop */
-      hint_counter = gwenesis_vdp_regs[10];
-
-      screen_height = REG1_PAL ? 240 : 224;
-      screen_width = REG12_MODE_H40 ? 320 : 256;
-      lines_per_frame = REG1_PAL ? LINES_PER_FRAME_PAL : LINES_PER_FRAME_NTSC;
-      vert_screen_offset = REG1_PAL ? 0 : 320 * (240 - 224) / 2;
-
-      hori_screen_offset = 0; //REG12_MODE_H40 ? 0 : (320 - 256) / 2;
       screen = lcd_get_active_buffer();
       gwenesis_vdp_set_buffer(&screen[vert_screen_offset + hori_screen_offset]);
 

--- a/Core/Src/porting/nes/main_nes.c
+++ b/Core/Src/porting/nes/main_nes.c
@@ -346,8 +346,9 @@ static void blit_5to6(bitmap_t *bmp, uint16_t *framebuffer) {
 }
 #endif
 
-static void blit(bitmap_t *bmp, uint16_t *framebuffer)
+static void blit(bitmap_t *bmp)
 {
+    uint16_t *framebuffer = lcd_get_active_buffer()
     odroid_display_scaling_t scaling = odroid_display_get_scaling_mode();
     odroid_display_filter_t filtering = odroid_display_get_filter_mode();
 
@@ -375,8 +376,8 @@ static void blit(bitmap_t *bmp, uint16_t *framebuffer)
         assert(!"Unknown scaling mode");
         break;
     }
+    common_ingame_overlay();
 }
-
 
 void osd_blitscreen(bitmap_t *bmp)
 {
@@ -400,9 +401,7 @@ void osd_blitscreen(bitmap_t *bmp)
     PROFILING_START(t_blit);
 
     // This takes less than 1ms
-    pixel_t *fb = lcd_get_active_buffer();
-    blit(bmp, fb);
-    common_ingame_overlay();
+    blit(bmp);
     lcd_swap();
 
     PROFILING_END(t_blit);
@@ -428,7 +427,7 @@ static bool palette_update_cb(odroid_dialog_choice_t *option, odroid_dialog_even
    return event == ODROID_DIALOG_ENTER;
 }
 
-void osd_getinput(void)
+void osd_getinput(bitmap_t *bmp)
 {
     uint16 pad0 = 0;
     //char pal_name[16];
@@ -444,7 +443,11 @@ void osd_getinput(void)
             // {101, "More...", "", 1, &advanced_settings_cb},
             ODROID_DIALOG_CHOICE_LAST
     };
-    common_emu_input_loop(&joystick, options);
+    void _blit()
+    {
+      blit(bmp);
+    }
+    common_emu_input_loop(&joystick, options, &_blit);
 
     uint8_t turbo_buttons = odroid_settings_turbo_buttons_get();
     bool turbo_a = (joystick.values[ODROID_INPUT_A] && (turbo_buttons & 1));

--- a/Core/Src/porting/odroid_overlay.c
+++ b/Core/Src/porting/odroid_overlay.c
@@ -4,17 +4,17 @@
 #include "odroid_system.h"
 #include "odroid_overlay.h"
 
-int odroid_overlay_game_settings_menu(odroid_dialog_choice_t *extra_options)
+int odroid_overlay_game_settings_menu(odroid_dialog_choice_t *extra_options, void_callback_t repaint)
 {
     return 0;
 }
 
-int odroid_overlay_game_debug_menu(void)
+int odroid_overlay_game_debug_menu(void_callback_t repaint)
 {
     return 0;
 }
 
-int odroid_overlay_game_menu()
+int odroid_overlay_game_menu(odroid_dialog_choice_t *extra_options, void_callback_t repaint)
 {
     return 0;
 }
@@ -47,14 +47,12 @@ int odroid_overlay_game_menu()
 #if CHEAT_CODES == 1
 static retro_emulator_file_t *CHOSEN_FILE = NULL;
 #endif
-// static uint16_t *overlay_buffer = NULL;
+
 static uint16_t overlay_buffer[ODROID_SCREEN_WIDTH * 32 * 2] __attribute__((aligned(4)));
-static short dialog_open_depth = 0;
 static short font_size = 8;
 
 void odroid_overlay_init()
 {
-    // overlay_buffer = (uint16_t *)rg_alloc(ODROID_SCREEN_WIDTH * 32 * 2, MEM_SLOW);
     odroid_overlay_set_font_size(odroid_settings_FontSize_get());
 }
 
@@ -193,7 +191,6 @@ void odroid_overlay_draw_fill_rect(int x, int y, int width, int height, uint16_t
     }
 }
 
-
 static void draw_clock_digit(uint16_t *fb, const uint8_t clock, uint16_t px, uint16_t py, uint16_t color)
 {
     static const unsigned char *CLOCK_DIGITS[] = {img_clock_00, img_clock_01, img_clock_02, img_clock_03, img_clock_04, img_clock_05, img_clock_06, img_clock_07, img_clock_08, img_clock_09};
@@ -230,7 +227,6 @@ void odroid_overlay_clock(int x_pos, int y_pos)
     draw_clock_digit(dst_img, hour % 10, x_pos + 8, y_pos, curr_colors->sel_c);
     draw_clock_digit(dst_img, hour / 10, x_pos, y_pos, curr_colors->sel_c);
 };
-
 
 void odroid_overlay_draw_battery(int x_pos, int y_pos)
 {
@@ -358,18 +354,16 @@ uint16_t get_shined_pixel(uint16_t color, uint16_t shined)
 __attribute__((optimize("unroll-loops")))
 void odroid_overlay_darken_all()
 {
-    if (dialog_open_depth <= 0)
-    { //darken bg
-        uint16_t mgic = 0b0000100000100001;
-        uint16_t *dst_img = lcd_get_active_buffer();
-        if ((dst_img[0] == mgic) || is_lcd_swap_pending())
-            return;
-        for (int y = 0; y < ODROID_SCREEN_HEIGHT; y++)
-            for (int x = 0; x < ODROID_SCREEN_WIDTH; x++)
-                dst_img[y * ODROID_SCREEN_WIDTH + x] = get_darken_pixel(dst_img[y * ODROID_SCREEN_WIDTH + x], 40);
+    uint16_t mgic = 0b0000100000100001;
+    uint16_t *dst_img = lcd_get_active_buffer();
+    if (dst_img[0] == mgic)
+        return;
 
-        dst_img[0] = mgic;
-    }
+    for (int y = 0; y < ODROID_SCREEN_HEIGHT; y++)
+        for (int x = 0; x < ODROID_SCREEN_WIDTH; x++)
+            dst_img[y * ODROID_SCREEN_WIDTH + x] = get_darken_pixel(dst_img[y * ODROID_SCREEN_WIDTH + x], 40);
+
+    dst_img[0] = mgic;
 }
 
 void odroid_overlay_draw_dialog(const char *header, odroid_dialog_choice_t *options, int sel)
@@ -638,7 +632,7 @@ void odroid_overlay_draw_dialog(const char *header, odroid_dialog_choice_t *opti
     rg_free(i_height);
 }
 
-int odroid_overlay_dialog_find_next_item(odroid_dialog_choice_t *options, int size, int selected_index, int direction)
+static int odroid_overlay_dialog_find_next_item(odroid_dialog_choice_t *options, int size, int selected_index, int direction)
 {
     size--; // Ignore last ODROID_DIALOG_CHOICE_LAST entry
 
@@ -674,36 +668,56 @@ int odroid_overlay_dialog_find_next_item(odroid_dialog_choice_t *options, int si
     return selected_index;
 }
 
-int odroid_overlay_dialog_live(const char *header, odroid_dialog_choice_t *options, int selected, repaint_callback_t callback)
+// Please note: It is up to the caller to restore the screen
+int odroid_overlay_dialog(const char *header, odroid_dialog_choice_t *options, int selected, void_callback_t repaint)
 {
     int options_count = get_dialog_items_count(options);
     int sel = odroid_overlay_dialog_find_next_item(options, options_count, selected < 0 ? (options_count + selected) : selected, 0);
+    int last_sel = sel;
     int last_key = -1;
     int repeat = 0;
     bool select = false;
-    bool initial = true;
+    bool debounce = true;
+    bool clone = true;
     odroid_gamepad_state_t joystick;
 
-    lcd_sync();
-    lcd_swap();
-    HAL_Delay(20);
-    odroid_overlay_darken_all();
-    lcd_sync();
-    odroid_overlay_draw_dialog(header, options, sel);
-    dialog_open_depth++;
+    void _repaint()
+    {
+        wdog_refresh();
+
+        // Repaint background (if enabled)
+        if (repaint != NULL)
+        {
+            repaint();
+        }
+        // Darken background (if needed)
+        odroid_overlay_darken_all();
+        // Draw dialog on top of darken background
+        odroid_overlay_draw_dialog(header, options, sel);
+        // Show
+        lcd_swap_with_wait();
+
+        // Important: Clone full frame once to avoid any initial discrepancies between buffers to avoid flickering.
+        if (clone) {
+            lcd_clone();
+            clone = false;
+        }
+    }
 
     while (1)
     {
-        wdog_refresh();
+        _repaint();
+
         odroid_input_read_gamepad(&joystick);
 
         // Ignore all buttons until all buttons are released once (only on entry)
-        if (initial && !odroid_input_key_is_pressed(ODROID_INPUT_ANY)) {
-            initial = false;
+        if (debounce && !odroid_input_key_is_pressed(ODROID_INPUT_ANY)) {
+            wdog_refresh();
             HAL_Delay(50); // Poor mans debounce
+            debounce = false;
         }
 
-        if ((last_key < 0 || ((repeat >= 30) && (repeat % 5 == 0))) && !initial)
+        if (!debounce && (last_key < 0 || ((repeat >= 30) && (repeat % 5 == 0))))
         {
             if (joystick.values[ODROID_INPUT_UP]) // G&W UP button
             {
@@ -808,6 +822,7 @@ int odroid_overlay_dialog_live(const char *header, odroid_dialog_choice_t *optio
                     break;
             }
         }
+        last_sel = sel;
         if (repeat > 0)
             repeat++;
         if (last_key >= 0)
@@ -818,35 +833,18 @@ int odroid_overlay_dialog_live(const char *header, odroid_dialog_choice_t *optio
                 repeat = 0;
             }
         }
-
-        if (callback != NULL)
-        {
-            callback();
-            dialog_open_depth--;
-        }
-        odroid_overlay_darken_all();
-        odroid_overlay_draw_dialog(header, options, sel);
-        if (callback != NULL)
-        {
-            dialog_open_depth++;
-        }
-
-        lcd_swap();
-        HAL_Delay(20);
     }
 
-    odroid_input_wait_for_key(last_key, false);
-
-    odroid_display_force_refresh();
-
-    dialog_open_depth--;
+    // Keep paint loop running until the button is released
+    int tmp_sel = sel;
+    sel = last_sel;
+    do {
+        odroid_input_read_gamepad(&joystick);
+        _repaint();
+    } while (joystick.values[last_key] == 1);
+    sel = tmp_sel;
 
     return sel < 0 ? sel : options[sel].id;
-}
-
-int odroid_overlay_dialog(const char *header, odroid_dialog_choice_t *options, int selected)
-{
-    return odroid_overlay_dialog_live(header, options, selected, NULL);
 }
 
 int odroid_overlay_confirm(const char *text, bool yes_selected)
@@ -858,7 +856,7 @@ int odroid_overlay_confirm(const char *text, bool yes_selected)
         {0, curr_lang->s_No, "", 1, NULL},
         ODROID_DIALOG_CHOICE_LAST,
     };
-    return odroid_overlay_dialog(curr_lang->s_PlsChose, choices, yes_selected ? 2 : 3);
+    return odroid_overlay_dialog(curr_lang->s_PlsChose, choices, yes_selected ? 2 : 3, NULL); //TODO add repaint callback
 }
 
 void odroid_overlay_alert(const char *text)
@@ -869,12 +867,7 @@ void odroid_overlay_alert(const char *text)
         {1, curr_lang->s_OK, "", 1, NULL},
         ODROID_DIALOG_CHOICE_LAST,
     };
-    odroid_overlay_dialog(curr_lang->s_Confirm, choices, 2);
-}
-
-bool odroid_overlay_dialog_is_open(void)
-{
-    return dialog_open_depth > 0;
+    odroid_overlay_dialog(curr_lang->s_Confirm, choices, 2, NULL); //TODO add repaint callback
 }
 
 static bool volume_update_cb(odroid_dialog_choice_t *option, odroid_dialog_event_t event, uint32_t repeat)
@@ -1046,7 +1039,7 @@ static bool turbo_buttons_update_cb(odroid_dialog_choice_t *option, odroid_dialo
     return event == ODROID_DIALOG_ENTER;
 }
 
-int odroid_overlay_settings_menu_live(odroid_dialog_choice_t *extra_options, repaint_callback_t callback)
+int odroid_overlay_settings_menu(odroid_dialog_choice_t *extra_options, void_callback_t repaint)
 {
     static char bright_value[25];
     static char volume_value[25];
@@ -1067,16 +1060,11 @@ int odroid_overlay_settings_menu_live(odroid_dialog_choice_t *extra_options, rep
         memcpy(&options[options_count], extra_options, (extra_options_count + 1) * sizeof(odroid_dialog_choice_t));
     }
 
-    int ret = odroid_overlay_dialog_live(curr_lang->s_OptionsTit, options, 0, callback);
+    int ret = odroid_overlay_dialog(curr_lang->s_OptionsTit, options, 0, repaint);
 
     odroid_settings_commit();
 
     return ret;
-}
-
-int odroid_overlay_settings_menu(odroid_dialog_choice_t *extra_options)
-{
-    return odroid_overlay_settings_menu_live(extra_options, NULL);
 }
 
 static void draw_game_status_bar(runtime_stats_t stats)
@@ -1101,7 +1089,8 @@ static void draw_game_status_bar(runtime_stats_t stats)
     odroid_overlay_draw_battery(ODROID_SCREEN_WIDTH - 22, ODROID_SCREEN_HEIGHT - 13);
 }
 
-int odroid_overlay_game_settings_menu(odroid_dialog_choice_t *extra_options)
+int
+odroid_overlay_game_settings_menu(odroid_dialog_choice_t *extra_options, void_callback_t repaint)
 {
     char speedup_value[15];
     char scaling_value[15];
@@ -1126,17 +1115,15 @@ int odroid_overlay_game_settings_menu(odroid_dialog_choice_t *extra_options)
     }
 
     odroid_audio_mute(true);
-    while (odroid_input_key_is_pressed(ODROID_INPUT_ANY))
-        wdog_refresh();
 
-    int r = odroid_overlay_settings_menu(options);
+    int r = odroid_overlay_settings_menu(options, repaint);
 
     odroid_audio_mute(false);
 
     return r;
 }
 
-int odroid_overlay_game_debug_menu(void)
+int odroid_overlay_game_debug_menu(void_callback_t repaint)
 {
     odroid_dialog_choice_t options[12] = {
         {10, "Screen Res", "A", 1, NULL},
@@ -1147,10 +1134,7 @@ int odroid_overlay_game_debug_menu(void)
         {10, "Registers", "C", 1, NULL},
         ODROID_DIALOG_CHOICE_LAST,
     };
-
-    while (odroid_input_key_is_pressed(ODROID_INPUT_ANY))
-        wdog_refresh();
-    return odroid_overlay_dialog("Debugging", options, 0);
+    return odroid_overlay_dialog("Debugging", options, 0, repaint);
 }
 
 #if CHEAT_CODES == 1
@@ -1196,15 +1180,28 @@ static bool show_cheat_dialog()
         choices[i].update_cb = cheat_update_cb;
     }
     choices[CHOSEN_FILE->cheat_count] = last;
-    odroid_overlay_dialog(curr_lang->s_Cheat_Codes_Title, choices, 0);
+    odroid_overlay_dialog(curr_lang->s_Cheat_Codes_Title, choices, 0, NULL); //TODO add repaint callback
 
     rg_free(choices);
     odroid_settings_commit();
     return false;
 }
 #endif
-int odroid_overlay_game_menu(odroid_dialog_choice_t *extra_options)
+
+int odroid_overlay_game_menu(odroid_dialog_choice_t *extra_options, void_callback_t repaint)
 {
+    // Collect stats before freezing emulation
+    runtime_stats_t stats = odroid_system_get_stats();
+
+    void _repaint()
+    {
+        if (repaint != NULL)
+        {
+            repaint();
+        }
+        draw_game_status_bar(stats);
+    }
+
 #if CHEAT_CODES == 1
     odroid_dialog_choice_t choices[12];
     bool cheat_update_support = false;
@@ -1307,17 +1304,10 @@ int odroid_overlay_game_menu(odroid_dialog_choice_t *extra_options)
         }
     }
 
-    // Collect stats before freezing emulation with wait_all_keys_released()
-    runtime_stats_t stats = odroid_system_get_stats();
-
     odroid_audio_mute(true);
-    while (odroid_input_key_is_pressed(ODROID_INPUT_ANY))
-        wdog_refresh();
-    draw_game_status_bar(stats);
 
-    lcd_sync();
-
-    int r = odroid_overlay_dialog(curr_lang->s_Retro_Go_options, choices, 0);
+    lcd_wait_if_swap_pending(); // Wait for a known good state
+    int r = odroid_overlay_dialog(curr_lang->s_Retro_Go_options, choices, 0, &_repaint);
 
     // Clear startup file so we boot into the retro-go gui
     odroid_settings_StartupFile_set(NULL);
@@ -1335,10 +1325,10 @@ int odroid_overlay_game_menu(odroid_dialog_choice_t *extra_options)
         odroid_system_emu_load_state(0);
         break; // TODO: Reload emulator?
     case 40:
-        odroid_overlay_game_settings_menu(extra_options);
+        odroid_overlay_game_settings_menu(extra_options, &_repaint);
         break;
     case 50:
-        odroid_overlay_game_debug_menu();
+        odroid_overlay_game_debug_menu(&_repaint);
         break;
 #if CHEAT_CODES == 1
     case 60:

--- a/Core/Src/porting/odroid_overlay.c
+++ b/Core/Src/porting/odroid_overlay.c
@@ -354,16 +354,11 @@ uint16_t get_shined_pixel(uint16_t color, uint16_t shined)
 __attribute__((optimize("unroll-loops")))
 void odroid_overlay_darken_all()
 {
-    uint16_t mgic = 0b0000100000100001;
     uint16_t *dst_img = lcd_get_active_buffer();
-    if (dst_img[0] == mgic)
-        return;
 
     for (int y = 0; y < ODROID_SCREEN_HEIGHT; y++)
         for (int x = 0; x < ODROID_SCREEN_WIDTH; x++)
             dst_img[y * ODROID_SCREEN_WIDTH + x] = get_darken_pixel(dst_img[y * ODROID_SCREEN_WIDTH + x], 40);
-
-    dst_img[0] = mgic;
 }
 
 void odroid_overlay_draw_dialog(const char *header, odroid_dialog_choice_t *options, int sel)

--- a/Core/Src/porting/smsplusgx/main_smsplusgx.c
+++ b/Core/Src/porting/smsplusgx/main_smsplusgx.c
@@ -361,6 +361,14 @@ void sms_pcm_submit() {
     }
 }
 
+static void blit()
+{
+    pixel_t* curr_framebuffer = lcd_get_active_buffer();
+    if (sms.console == CONSOLE_GG)     blit_gg(&bitmap, curr_framebuffer);
+    else                               blit_sms(&bitmap, curr_framebuffer);
+    common_ingame_overlay();
+}
+
 static void sms_draw_frame()
 {
   static uint32_t lastFPSTime = 0;
@@ -368,7 +376,6 @@ static void sms_draw_frame()
 
   uint32_t currentTime = HAL_GetTick();
   uint32_t delta = currentTime - lastFPSTime;
-  pixel_t* curr_framebuffer = NULL;
 
   frames++;
 
@@ -387,10 +394,7 @@ static void sms_draw_frame()
                           ((0b0000000000011111 & p));
   }
 
-  curr_framebuffer = lcd_get_active_buffer();
-  if (sms.console == CONSOLE_GG)     blit_gg(&bitmap, curr_framebuffer);
-  else                               blit_sms(&bitmap, curr_framebuffer);
-  common_ingame_overlay();
+  blit();
   lcd_swap();
 }
 
@@ -524,7 +528,7 @@ app_main_smsplusgx(uint8_t load_state, uint8_t start_paused, uint8_t save_slot, 
         odroid_dialog_choice_t options[] = {
             ODROID_DIALOG_CHOICE_LAST
         };
-        common_emu_input_loop(&joystick, options);
+        common_emu_input_loop(&joystick, options, &blit);
 
         bool drawFrame = common_emu_frame_loop();
         uint8_t turbo_buttons = odroid_settings_turbo_buttons_get();
@@ -542,8 +546,8 @@ app_main_smsplusgx(uint8_t load_state, uint8_t start_paused, uint8_t save_slot, 
 
         if (drawFrame) {
             sms_draw_frame();
-            sms_pcm_submit();
         }
+        sms_pcm_submit();
 
         if(!common_emu_state.skip_frames)
         {

--- a/Core/Src/porting/wsv/main_wsv.c
+++ b/Core/Src/porting/wsv/main_wsv.c
@@ -121,9 +121,6 @@ static inline void screen_blit_nn(int32_t dest_width, int32_t dest_height)
 #ifdef PROFILING_ENABLED
     printf("Blit: %d us\n", (1000000 * PROFILING_DIFF(t_blit)) / t_blit_t0.SecondFraction);
 #endif
-    common_ingame_overlay();
-
-    lcd_swap();
 }
 
 static void screen_blit_bilinear(int32_t dest_width)
@@ -185,9 +182,6 @@ static void screen_blit_bilinear(int32_t dest_width)
 #ifdef PROFILING_ENABLED
     printf("Blit: %d us\n", (1000000 * PROFILING_DIFF(t_blit)) / t_blit_t0.SecondFraction);
 #endif
-    common_ingame_overlay();
-
-    lcd_swap();
 }
 
 static inline void screen_blit_v3to5(void) {
@@ -246,9 +240,6 @@ static inline void screen_blit_v3to5(void) {
 #ifdef PROFILING_ENABLED
     printf("Blit: %d us\n", (1000000 * PROFILING_DIFF(t_blit)) / t_blit_t0.SecondFraction);
 #endif
-    common_ingame_overlay();
-
-    lcd_swap();
 }
 
 
@@ -326,9 +317,6 @@ static inline void screen_blit_jth(void) {
 #ifdef PROFILING_ENABLED
     printf("Blit: %d us\n", (1000000 * PROFILING_DIFF(t_blit)) / t_blit_t0.SecondFraction);
 #endif
-    common_ingame_overlay();
-
-    lcd_swap();
 }
 
 static void blit(void)
@@ -359,7 +347,6 @@ static void blit(void)
             assert(!"Unknown filtering mode");
         }
         break;
-        break;
     case ODROID_DISPLAY_SCALING_FULL:
         // full height, full width
         switch (filtering) {
@@ -389,6 +376,7 @@ static void blit(void)
         assert(!"Unknown scaling mode");
         break;
     }
+    common_ingame_overlay();
 }
 
 void wsv_render_image() {
@@ -513,7 +501,7 @@ int app_main_wsv(uint8_t load_state, uint8_t start_paused, uint8_t save_slot)
         bool drawFrame = common_emu_frame_loop();
 
         odroid_input_read_gamepad(&joystick);
-        common_emu_input_loop(&joystick, options);
+        common_emu_input_loop(&joystick, options, &blit);
         uint8_t turbo_buttons = odroid_settings_turbo_buttons_get();
         bool turbo_a = (joystick.values[ODROID_INPUT_A] && (turbo_buttons & 1));
         bool turbo_b = (joystick.values[ODROID_INPUT_B] && (turbo_buttons & 2));
@@ -528,6 +516,7 @@ int app_main_wsv(uint8_t load_state, uint8_t start_paused, uint8_t save_slot)
         supervision_exec((uint16 *)wsv_framebuffer);
         if (drawFrame) {
             blit();
+            lcd_swap();
         }
         wsv_pcm_submit();
         if(!common_emu_state.skip_frames){

--- a/Core/Src/retro-go/gui.c
+++ b/Core/Src/retro-go/gui.c
@@ -326,8 +326,7 @@ void gui_redraw_callback()
 void gui_redraw()
 {
     gui_redraw_callback();
-
-    lcd_swap();
+    lcd_swap_with_wait();
 }
 
 void gui_draw_navbar()

--- a/Core/Src/retro-go/rg_emulators.c
+++ b/Core/Src/retro-go/rg_emulators.c
@@ -337,7 +337,7 @@ void emulator_show_file_info(retro_emulator_file_t *file)
     sprintf(choices[3].value, "%d KB", file->img_size / 1024);
 	#endif
 
-    odroid_overlay_dialog_live(curr_lang->s_GameProp, choices, -1, &gui_redraw_callback);
+    odroid_overlay_dialog(curr_lang->s_GameProp, choices, -1, &gui_redraw_callback);
 }
 
 #if CHEAT_CODES == 1
@@ -436,7 +436,7 @@ bool emulator_show_file_menu(retro_emulator_file_t *file)
 #endif
     }
 
-    int sel = odroid_overlay_dialog_live(file->name, choices, has_save ? 0 : 1, &gui_redraw_callback);
+    int sel = odroid_overlay_dialog(file->name, choices, has_save ? 0 : 1, &gui_redraw_callback);
 
     if (sel == 0 || sel == 1) {
         gui_save_current_tab();


### PR DESCRIPTION
This is a rather big update that adds support for live updates to the background when showing in-game dialog boxes. 
Initially: clock and battery update and more importantly live preview of scale and filtering changes etc.
It also fixed the annoying flickering and black negative artifact of the in-game overlay when clearing it.

All emulators has been changed to take advantage of this new system.

This PR also needs https://github.com/sylverb/retro-go-stm32/pull/6