### PR TITLE
Single blank tab frame fix

### DIFF
--- a/Core/Src/retro-go/rg_emulators.c
+++ b/Core/Src/retro-go/rg_emulators.c
@@ -90,22 +90,16 @@ static void event_handler(gui_event_t event, tab_t *tab)
     if (event == KEY_PRESS_A)
     {
         emulator_show_file_menu(file);
-        gui_redraw();
     }
     else if (event == KEY_PRESS_B)
     {
         emulator_show_file_info(file);
-        gui_redraw();
     }
     else if (event == TAB_IDLE)
     {
-        //if (file->checksum == 0) {
-        //    emulator_crc32_file(file);
-        // }
     }
     else if (event == TAB_REDRAW)
     {
-        gui_redraw();
     }
 }
 

--- a/Core/Src/retro-go/rg_main.c
+++ b/Core/Src/retro-go/rg_main.c
@@ -134,7 +134,6 @@ static bool colors_update_cb(odroid_dialog_choice_t *option, odroid_dialog_event
     option->value[0] = 0;
     option->value[10] = 0;
     memcpy(option->value + 2, curr_colors, sizeof(colors_t));
-    //sprintf(option->value, "%s", curr_colors->name);
     return event == ODROID_DIALOG_ENTER;
 }
 
@@ -180,7 +179,6 @@ static bool lang_update_cb(odroid_dialog_choice_t *option, odroid_dialog_event_t
     }
     curr_lang = (lang_t *)gui_lang[lang];
     sprintf(option->value, "%s", curr_lang->s_LangName);
-    //sprintf(option->label, "%s", curr_lang->s_Lang);
     return event == ODROID_DIALOG_ENTER;
 }
 
@@ -301,8 +299,6 @@ static inline bool tab_enabled(tab_t *tab)
 #if INTFLASH_BANK == 2
 void soft_reset_do(void)
 {
-    uint32_t addr = 0x08000000;
-    //         0x08000000;//APP_ADDR0;
     *((uint32_t *)0x2001FFF8) = 0x544F4F42; // "BOOT"
     *((uint32_t *)0x2001FFFC) = 0x08000000; // vector table
 
@@ -361,6 +357,170 @@ static bool debug_menu_debug_cr_cb(odroid_dialog_choice_t *option, odroid_dialog
     return event == ODROID_DIALOG_ENTER;
 }
 
+static void handle_debug_menu()
+{
+    uint8_t jedec_id[3];
+    char jedec_id_str[16];
+    uint8_t status;
+    char status_str[8];
+    uint8_t config;
+    char config_str[8];
+    char erase_size_str[32];
+    char dbgmcu_id_str[16];
+    char dbgmcu_cr_str[16];
+    char dbgmcu_clock_str[16];
+
+    // Read jedec id and status register from the external flash
+    OSPI_DisableMemoryMappedMode();
+    OSPI_ReadJedecId(&jedec_id[0]);
+    OSPI_ReadSR(&status);
+    OSPI_ReadCR(&config);
+    OSPI_EnableMemoryMappedMode();
+
+    snprintf(jedec_id_str, sizeof(jedec_id_str), "%02X %02X %02X", jedec_id[0], jedec_id[1], jedec_id[2]);
+    snprintf(status_str, sizeof(status_str), "0x%02X", status);
+    snprintf(config_str, sizeof(config_str), "0x%02X", config);
+    snprintf(erase_size_str, sizeof(erase_size_str), "%ld kB", OSPI_GetSmallestEraseSize() / 1024);
+    snprintf(dbgmcu_id_str, sizeof(dbgmcu_id_str), "0x%08lX", DBGMCU->IDCODE);
+
+    odroid_dialog_choice_t debuginfo[] = {
+            {-1, curr_lang->s_Flash_JEDEC_ID, (char *)jedec_id_str, 0, NULL},
+            {-1, curr_lang->s_Flash_Name, (char *)OSPI_GetFlashName(), 0, NULL},
+            {-1, curr_lang->s_Flash_SR, (char *)status_str, 0, NULL},
+            {-1, curr_lang->s_Flash_CR, (char *)config_str, 0, NULL},
+            {-1, curr_lang->s_Smallest_erase, erase_size_str, 0, NULL},
+            ODROID_DIALOG_CHOICE_SEPARATOR,
+            {-1, curr_lang->s_DBGMCU_IDCODE, dbgmcu_id_str, 0, NULL},
+            {-1, curr_lang->s_DBGMCU_CR, dbgmcu_cr_str, 0, debug_menu_debug_cr_cb},
+            {1, curr_lang->s_DBGMCU_clock, dbgmcu_clock_str, 1, debug_menu_debug_clock_cb},
+            ODROID_DIALOG_CHOICE_SEPARATOR,
+            {0, curr_lang->s_Close, "", 1, NULL},
+            ODROID_DIALOG_CHOICE_LAST};
+
+    odroid_overlay_dialog(curr_lang->s_Debug_Title, debuginfo, -1, &gui_redraw_callback);
+    odroid_settings_commit();
+}
+
+static void handle_about_menu()
+{
+    odroid_dialog_choice_t choices[] = {
+            {-1, curr_lang->s_Version, GIT_HASH, 0, NULL},
+            {-1, curr_lang->s_Author, "ducalex", 0, NULL},
+            {-1, curr_lang->s_Author_, "kbeckmann", 0, NULL},
+            {-1, curr_lang->s_Author_, "stacksmashing", 0, NULL},
+            {-1, curr_lang->s_Author_, "Sylver Bruneau", 0, NULL},
+            {-1, curr_lang->s_Author_, "bzhxx", 0, NULL},
+            {-1, curr_lang->s_UI_Mod, "orzeus", 0, NULL},
+            {-1, curr_lang->s_Author_, "Benjamin S\xf8lberg", 0, NULL},
+            ODROID_DIALOG_CHOICE_SEPARATOR,
+            {-1, curr_lang->s_Lang, (char *)curr_lang->s_LangAuthor, 0, NULL},
+            ODROID_DIALOG_CHOICE_SEPARATOR,
+            {2, curr_lang->s_Debug_menu, "", 1, NULL},
+            {1, curr_lang->s_Reset_settings, "", 1, NULL},
+            ODROID_DIALOG_CHOICE_SEPARATOR,
+            {0, curr_lang->s_Close, "", 1, NULL},
+            ODROID_DIALOG_CHOICE_LAST};
+
+    int sel = odroid_overlay_dialog(curr_lang->s_Retro_Go, choices, -1, &gui_redraw_callback);
+    if (sel == 1)
+    {
+        // Reset settings
+        if (odroid_overlay_confirm(curr_lang->s_Confirm_Reset_settings, false, &gui_redraw_callback) == 1)
+        {
+            odroid_settings_reset();
+            odroid_system_switch_app(0); // reset
+        }
+    }
+    else if (sel == 2)
+    {
+        handle_debug_menu();
+    }
+}
+
+static void handle_options_menu()
+{
+    char font_value[16];
+    char timeout_value[16];
+#if COVERFLOW != 0
+    char theme_value[16];
+#endif
+    char colors_value[16];
+    char lang_value[64];
+    char ov_value[64];
+
+    odroid_dialog_choice_t choices[] = {
+        ODROID_DIALOG_CHOICE_SEPARATOR,
+        {0, curr_lang->s_Font, font_value, 1, &font_update_cb},
+        {0, curr_lang->s_LangUI, lang_value, 1, &lang_update_cb},
+#if COVERFLOW != 0
+        {0, curr_lang->s_Theme_Title, theme_value, 1, &theme_update_cb},
+#endif
+        {0x0F0F0E0E, curr_lang->s_Colors, colors_value, 1, &colors_update_cb},
+        ODROID_DIALOG_CHOICE_SEPARATOR,
+        {0, curr_lang->s_Idle_power_off, timeout_value, 1, &main_menu_timeout_cb},
+        ODROID_DIALOG_CHOICE_SEPARATOR,
+        {0, curr_lang->s_CPU_Overclock, ov_value, 1, &main_menu_cpu_oc_cb},
+#if INTFLASH_BANK == 2
+    //{9, curr_lang->s_Reboot, curr_lang->s_Original_system, 1, NULL},
+#endif
+        ODROID_DIALOG_CHOICE_LAST};
+#if INTFLASH_BANK == 2
+    int r = odroid_overlay_settings_menu(choices, &gui_redraw_callback);
+    if (r == 9)
+        soft_reset_do();
+#else
+    odroid_overlay_settings_menu(choices, &gui_redraw_callback);
+#endif
+    if (oc_level_gets() != oc_level_get())
+        //reboot;
+        if (odroid_overlay_confirm(curr_lang->s_Confirm_OC_Reboot, false, &gui_redraw_callback) == 1)
+            odroid_system_switch_app(0);
+}
+
+static void handle_time_menu()
+{
+    char time_str[14];
+    char date_str[24];
+
+    odroid_dialog_choice_t rtcinfo[] = {
+            {0, curr_lang->s_Time, time_str, 1, &time_display_cb},
+            {1, curr_lang->s_Date, date_str, 1, &date_display_cb},
+            ODROID_DIALOG_CHOICE_LAST};
+    int sel = odroid_overlay_dialog(curr_lang->s_Time_Title, rtcinfo, 0, &gui_redraw_callback);
+
+    if (sel == 0)
+    {
+        static char hour_value[8];
+        static char minute_value[8];
+        static char second_value[8];
+
+        // Time setup
+        odroid_dialog_choice_t timeoptions[8] = {
+                {0, curr_lang->s_Hour, hour_value, 1, &hour_update_cb},
+                {1, curr_lang->s_Minute, minute_value, 1, &minute_update_cb},
+                {2, curr_lang->s_Second, second_value, 1, &second_update_cb},
+                ODROID_DIALOG_CHOICE_LAST};
+        sel = odroid_overlay_dialog(curr_lang->s_Time_setup, timeoptions, 0, &gui_redraw_callback);
+    }
+    else if (sel == 1)
+    {
+
+        static char day_value[8];
+        static char month_value[8];
+        static char year_value[8];
+        static char weekday_value[8];
+
+        // Date setup
+        odroid_dialog_choice_t dateoptions[8] = {
+                {2, curr_lang->s_Year, year_value, 1, &year_update_cb},
+                {1, curr_lang->s_Month, month_value, 1, &month_update_cb},
+                {0, curr_lang->s_Day, day_value, 1, &day_update_cb},
+                {-1, curr_lang->s_Weekday, weekday_value, 0, &weekday_update_cb},
+                ODROID_DIALOG_CHOICE_LAST};
+        sel = odroid_overlay_dialog(curr_lang->s_Date_setup, dateoptions, 0, &gui_redraw_callback);
+    }
+}
+
 void retro_loop()
 {
     tab_t *tab = gui_get_current_tab();
@@ -380,9 +540,6 @@ void retro_loop()
             last_key = i;
 
     gui.selected = odroid_settings_MainMenuSelectedTab_get();
-    // gui.theme      = odroid_settings_int32_get(KEY_GUI_THEME, 0);
-    // gui.show_empty = odroid_settings_int32_get(KEY_SHOW_EMPTY, 1);
-    // gui.show_cover = odroid_settings_int32_get(KEY_SHOW_COVER, 1);
 
     // This will upon power down disable the debug clock to save battery power
     odroid_system_set_sleep_hook(&sleep_hook_callback);
@@ -448,163 +605,15 @@ void retro_loop()
 
             if ((last_key == ODROID_INPUT_START) || (last_key == ODROID_INPUT_X))
             {
-                odroid_dialog_choice_t choices[] = {
-                    {-1, curr_lang->s_Version, GIT_HASH, 0, NULL},
-                    {-1, curr_lang->s_Author, "ducalex", 0, NULL},
-                    {-1, curr_lang->s_Author_, "kbeckmann", 0, NULL},
-                    {-1, curr_lang->s_Author_, "stacksmashing", 0, NULL},
-                    {-1, curr_lang->s_Author_, "Sylver Bruneau", 0, NULL},
-                    {-1, curr_lang->s_Author_, "bzhxx", 0, NULL},
-                    {-1, curr_lang->s_UI_Mod, "orzeus", 0, NULL},
-                    {-1, curr_lang->s_Author_, "Benjamin S\xf8lberg", 0, NULL},
-                    ODROID_DIALOG_CHOICE_SEPARATOR,
-                    {-1, curr_lang->s_Lang, curr_lang->s_LangAuthor, 0, NULL},
-                    ODROID_DIALOG_CHOICE_SEPARATOR,
-                    {2, curr_lang->s_Debug_menu, "", 1, NULL},
-                    {1, curr_lang->s_Reset_settings, "", 1, NULL},
-                    ODROID_DIALOG_CHOICE_SEPARATOR,
-                    {0, curr_lang->s_Close, "", 1, NULL},
-                    ODROID_DIALOG_CHOICE_LAST};
-
-                int sel = odroid_overlay_dialog(curr_lang->s_Retro_Go, choices, -1, &gui_redraw_callback);
-                if (sel == 1)
-                {
-                    // Reset settings
-                    if (odroid_overlay_confirm(curr_lang->s_Confirm_Reset_settings, false, &gui_redraw_callback) == 1)
-                    {
-                        odroid_settings_reset();
-                        odroid_system_switch_app(0); // reset
-                    }
-                }
-                else if (sel == 2)
-                {
-                    // Debug menu
-                    uint8_t jedec_id[3];
-                    char jedec_id_str[16];
-                    uint8_t status;
-                    char status_str[8];
-                    uint8_t config;
-                    char config_str[8];
-                    char erase_size_str[32];
-                    char dbgmcu_id_str[16];
-                    char dbgmcu_cr_str[16];
-                    char dbgmcu_clock_str[16];
-
-                    // Read jedec id and status register from the external flash
-                    OSPI_DisableMemoryMappedMode();
-                    OSPI_ReadJedecId(&jedec_id[0]);
-                    OSPI_ReadSR(&status);
-                    OSPI_ReadCR(&config);
-                    OSPI_EnableMemoryMappedMode();
-
-                    snprintf(jedec_id_str, sizeof(jedec_id_str), "%02X %02X %02X", jedec_id[0], jedec_id[1], jedec_id[2]);
-                    snprintf(status_str, sizeof(status_str), "0x%02X", status);
-                    snprintf(config_str, sizeof(config_str), "0x%02X", config);
-                    snprintf(erase_size_str, sizeof(erase_size_str), "%ld kB", OSPI_GetSmallestEraseSize() / 1024);
-                    snprintf(dbgmcu_id_str, sizeof(dbgmcu_id_str), "0x%08lX", DBGMCU->IDCODE);
-
-                    odroid_dialog_choice_t debuginfo[] = {
-                        {-1, curr_lang->s_Flash_JEDEC_ID, (char *)jedec_id_str, 0, NULL},
-                        {-1, curr_lang->s_Flash_Name, (char *)OSPI_GetFlashName(), 0, NULL},
-                        {-1, curr_lang->s_Flash_SR, (char *)status_str, 0, NULL},
-                        {-1, curr_lang->s_Flash_CR, (char *)config_str, 0, NULL},
-                        {-1, curr_lang->s_Smallest_erase, erase_size_str, 0, NULL},
-                        ODROID_DIALOG_CHOICE_SEPARATOR,
-                        {-1, curr_lang->s_DBGMCU_IDCODE, dbgmcu_id_str, 0, NULL},
-                        {-1, curr_lang->s_DBGMCU_CR, dbgmcu_cr_str, 0, debug_menu_debug_cr_cb},
-                        {1, curr_lang->s_DBGMCU_clock, dbgmcu_clock_str, 1, debug_menu_debug_clock_cb},
-                        ODROID_DIALOG_CHOICE_SEPARATOR,
-                        {0, curr_lang->s_Close, "", 1, NULL},
-                        ODROID_DIALOG_CHOICE_LAST};
-
-                    odroid_overlay_dialog(curr_lang->s_Debug_Title, debuginfo, -1, &gui_redraw_callback);
-                    odroid_settings_commit();
-                }
+                handle_about_menu();
             }
             else if ((last_key == ODROID_INPUT_VOLUME) || (last_key == ODROID_INPUT_Y))
             {
-                char font_value[16];
-                char timeout_value[16];
-#if COVERFLOW != 0
-                char theme_value[16];
-#endif
-                char colors_value[16];
-                char lang_value[64];
-                char ov_value[64];
-
-                odroid_dialog_choice_t choices[] = {
-                    ODROID_DIALOG_CHOICE_SEPARATOR,
-                    {0, curr_lang->s_Font, font_value, 1, &font_update_cb},
-                    {0, curr_lang->s_LangUI, lang_value, 1, &lang_update_cb},
-#if COVERFLOW != 0
-                     //ODROID_DIALOG_CHOICE_SEPARATOR,
-                    {0, curr_lang->s_Theme_Title, theme_value, 1, &theme_update_cb},
-#endif
-                    {0x0F0F0E0E, curr_lang->s_Colors, colors_value, 1, &colors_update_cb},
-                    ODROID_DIALOG_CHOICE_SEPARATOR,
-                    {0, curr_lang->s_Idle_power_off, timeout_value, 1, &main_menu_timeout_cb},
-                    ODROID_DIALOG_CHOICE_SEPARATOR,
-                    {0, curr_lang->s_CPU_Overclock, ov_value, 1, &main_menu_cpu_oc_cb},
-#if INTFLASH_BANK == 2
-                    //{9, curr_lang->s_Reboot, curr_lang->s_Original_system, 1, NULL},
-#endif
-                    ODROID_DIALOG_CHOICE_LAST};
-#if INTFLASH_BANK == 2
-                int r = odroid_overlay_settings_menu(choices, &gui_redraw_callback);
-                if (r == 9)
-                    soft_reset_do();
-#else
-                odroid_overlay_settings_menu(choices, &gui_redraw_callback);
-#endif
-                if (oc_level_gets() != oc_level_get())
-                    //reboot;
-                    if (odroid_overlay_confirm(curr_lang->s_Confirm_OC_Reboot, false, &gui_redraw_callback) == 1)
-                        odroid_system_switch_app(0);
+                handle_options_menu();
             }
-            // TIME menu
             else if (last_key == ODROID_INPUT_SELECT)
             {
-
-                char time_str[14];
-                char date_str[24];
-
-                odroid_dialog_choice_t rtcinfo[] = {
-                    {0, curr_lang->s_Time, time_str, 1, &time_display_cb},
-                    {1, curr_lang->s_Date, date_str, 1, &date_display_cb},
-                    ODROID_DIALOG_CHOICE_LAST};
-                int sel = odroid_overlay_dialog(curr_lang->s_Time_Title, rtcinfo, 0, &gui_redraw_callback);
-
-                if (sel == 0)
-                {
-                    static char hour_value[8];
-                    static char minute_value[8];
-                    static char second_value[8];
-
-                    // Time setup
-                    odroid_dialog_choice_t timeoptions[8] = {
-                        {0, curr_lang->s_Hour, hour_value, 1, &hour_update_cb},
-                        {1, curr_lang->s_Minute, minute_value, 1, &minute_update_cb},
-                        {2, curr_lang->s_Second, second_value, 1, &second_update_cb},
-                        ODROID_DIALOG_CHOICE_LAST};
-                    sel = odroid_overlay_dialog(curr_lang->s_Time_setup, timeoptions, 0, &gui_redraw_callback);
-                }
-                else if (sel == 1)
-                {
-
-                    static char day_value[8];
-                    static char month_value[8];
-                    static char year_value[8];
-                    static char weekday_value[8];
-
-                    // Date setup
-                    odroid_dialog_choice_t dateoptions[8] = {
-                        {2, curr_lang->s_Year, year_value, 1, &year_update_cb},
-                        {1, curr_lang->s_Month, month_value, 1, &month_update_cb},
-                        {0, curr_lang->s_Day, day_value, 1, &day_update_cb},
-                        {-1, curr_lang->s_Weekday, weekday_value, 0, &weekday_update_cb},
-                        ODROID_DIALOG_CHOICE_LAST};
-                    sel = odroid_overlay_dialog(curr_lang->s_Date_setup, dateoptions, 0, &gui_redraw_callback);
-                }
+                handle_time_menu();
             }
             else if (last_key == key_up)
             {
@@ -674,7 +683,12 @@ void retro_loop()
             odroid_system_sleep();
         }
 
-        gui_redraw();
+        // Only redraw if we haven't changed the tab as it has to be initialized first.
+        // This will remove an empty frame when changing to a new and uninitialized tab.
+        if (gui.selected == selected_tab_last)
+        {
+            gui_redraw();
+        }
     }
 }
 
@@ -683,16 +697,15 @@ void retro_loop()
 void app_check_data_loop()
 {
     static const uint8_t img_error[] = {
-        0x0F, 0xFC, 0x12, 0x4A, 0x12, 0x4A, //
-        0x20, 0x02, 0x24, 0x22, 0x4E, 0x72, //
-        0x40, 0x02, 0x43, 0xC2, 0x47, 0xE2, //
-        0x4C, 0x32, 0x40, 0x02, 0x40, 0x02, //
-        0x40, 0x02, 0x3F, 0xFC,             //
+        0x0F, 0xFC, 0x12, 0x4A, 0x12, 0x4A,
+        0x20, 0x02, 0x24, 0x22, 0x4E, 0x72,
+        0x40, 0x02, 0x43, 0xC2, 0x47, 0xE2,
+        0x4C, 0x32, 0x40, 0x02, 0x40, 0x02,
+        0x40, 0x02, 0x3F, 0xFC,
     };
 
     char s[22];
     int idle_s = uptime_get();
-    //     - gui.idle_start;
 
     printf("Flash Magic Check: %x at %p & %x at %p; \n", extflash_magic_sign, &extflash_magic_sign, intflash_magic_sign, &intflash_magic_sign);
     if (extflash_magic_sign != intflash_magic_sign)
@@ -741,7 +754,6 @@ void app_check_data_loop()
         }
         app_sleep_logo();
         GW_EnterDeepSleep();
-        //odroid_system_sleep();
     }
 }
 
@@ -823,7 +835,6 @@ void app_main(uint8_t boot_mode)
         odroid_system_switch_app(9);
     }    
     odroid_overlay_draw_fill_rect(0, 0, ODROID_SCREEN_WIDTH, ODROID_SCREEN_HEIGHT, curr_colors->bg_c);
-    // odroid_display_clear(0);
 
     //check data;
     app_check_data_loop();
@@ -835,8 +846,6 @@ void app_main(uint8_t boot_mode)
     if (boot_mode != 2)
         app_start_logo();
 #endif
-
-    // favorites_init();
 
     // Start the previously running emulator directly if it's a valid pointer.
     // If the user holds down the TIME button during startup,start the retro-go

--- a/Core/Src/retro-go/rg_main.c
+++ b/Core/Src/retro-go/rg_main.c
@@ -407,11 +407,6 @@ void retro_loop()
             if (!tab->initialized)
             {
                 gui_init_tab(tab);
-                gui_redraw();
-            }
-            else if (tab_enabled(tab))
-            {
-                gui_redraw();
             }
 
             if (!tab_enabled(tab))
@@ -525,8 +520,6 @@ void retro_loop()
                     odroid_overlay_dialog(curr_lang->s_Debug_Title, debuginfo, -1, &gui_redraw_callback);
                     odroid_settings_commit();
                 }
-
-                gui_redraw();
             }
             else if ((last_key == ODROID_INPUT_VOLUME) || (last_key == ODROID_INPUT_Y))
             {
@@ -567,8 +560,6 @@ void retro_loop()
                     //reboot;
                     if (odroid_overlay_confirm(curr_lang->s_Confirm_OC_Reboot, false, &gui_redraw_callback) == 1)
                         odroid_system_switch_app(0);
-
-                gui_redraw();
             }
             // TIME menu
             else if (last_key == ODROID_INPUT_SELECT)
@@ -614,8 +605,6 @@ void retro_loop()
                         ODROID_DIALOG_CHOICE_LAST};
                     sel = odroid_overlay_dialog(curr_lang->s_Date_setup, dateoptions, 0, &gui_redraw_callback);
                 }
-
-                gui_redraw();
             }
             else if (last_key == key_up)
             {


### PR DESCRIPTION
 Removed a single empty list screen frame when changing to a new uninitialized tab to make tab switching look more instantaneous.

**Code cleanup**
1. Extracted menu code into own functions to improve readability
2. Removed old dangling commented code
3. Removed a single warning when compiling with *INTFLASH_BANK=2*
4. Removed unnecessary calls to *gui_redraw()*