### PR TITLE
Fix for G&W emulator, sound generation runs with a framerate of 128hz and should not be sync'ed to display framerate

### DIFF
--- a/Core/Src/porting/gw/main_gw.c
+++ b/Core/Src/porting/gw/main_gw.c
@@ -556,9 +556,8 @@ int app_main_gw(uint8_t load_state, uint8_t save_slot)
         proc_cycles = get_dwt_cycles();
 
         /* update the screen only if there is no pending frame to render */
-        if (drawFrame)
+        if (!lcd_is_swap_pending() && drawFrame)
         {
-            common_sleep_while_lcd_swap_pending();
             _blit();
             gw_debug_bar();
             if(debug_display_ram == 1) gw_display_ram_overlay();


### PR DESCRIPTION
Reported by @retromin via Discord, thanks!