### PR TITLE
Fixed sound issues in the GB emulator

### DIFF
--- a/Core/Src/porting/gb/main_gb.c
+++ b/Core/Src/porting/gb/main_gb.c
@@ -363,7 +363,9 @@ static void blit(void)
 
 static void blit_and_swap(void)
 {
-    common_sleep_while_lcd_swap_pending();
+    // Temporary disabled as it causes sound jitter/issues (Verified in Super Mario Land 2.0 rom hack)
+    // common_sleep_while_lcd_swap_pending();
+
     blit();
     lcd_swap();
 }


### PR DESCRIPTION
Temporary disabled calls to common_sleep_while_lcd_swap_pending() in the GB emulator as it causes sound jitter/issues (Verified in Super Mario Land 2.0 rom hack)