### PR TITLE
Fixed an out-of-band screen update while scrolling games using coverflow

### DIFF
--- a/Core/Src/retro-go/gui.c
+++ b/Core/Src/retro-go/gui.c
@@ -309,8 +309,6 @@ void gui_scroll_list(tab_t *tab, scroll_mode_t mode)
 
     if (cur_cursor != old_cursor)
     {
-        gui_draw_notice(" ", curr_colors->bg_c);
-        gui_draw_list(tab);
         gui_event(TAB_SCROLL, tab);
     }
 }


### PR DESCRIPTION
Removed old and unneeded code that did an out-of-band screen update which caused a single frame jitter when using coverflow with images while scrolling the list.