### PR TITLE
LCD synchronization has been removed from all emulators as it was cau…

### DIFF
--- a/Core/Inc/gw_lcd.h
+++ b/Core/Inc/gw_lcd.h
@@ -3,6 +3,7 @@
 
 #include "stm32h7xx_hal.h"
 #include <stdint.h>
+#include <stdbool.h>
 
 #define GW_LCD_WIDTH  320
 #define GW_LCD_HEIGHT 240
@@ -28,14 +29,14 @@ void lcd_backlight_set(uint8_t brightness);
 void lcd_backlight_on();
 void lcd_backlight_off();
 void lcd_swap(void);
- void lcd_sync(void); // DEPRECATED
+void lcd_sync(void); // DEPRECATED
 void lcd_clone(void);
 void* lcd_get_active_buffer(void);
 void* lcd_get_inactive_buffer(void);
 void lcd_set_buffers(uint16_t *buf1, uint16_t *buf2);
 void lcd_wait_for_vblank(void);
 uint32_t lcd_is_swap_pending(void);
-uint32_t lcd_sleep_while_swap_pending(void);
+bool lcd_sleep_while_swap_pending(void);
 
 // To be used by fault handlers
 void lcd_reset_active_buffer(void);

--- a/Core/Inc/porting/common.h
+++ b/Core/Inc/porting/common.h
@@ -89,9 +89,3 @@ extern common_emu_state_t common_emu_state;
  * Drawable stuff over current emulation.
  */
 void common_ingame_overlay(void);
-
-/**
- * Will go to sleep and wait for an interrupt to save power while lcd swap is pending.
- * The LCD controller will generate an interrupt when the swap has been completed.
- */
-bool common_sleep_while_lcd_swap_pending(void);

--- a/Core/Src/gw_lcd.c
+++ b/Core/Src/gw_lcd.c
@@ -141,16 +141,14 @@ uint32_t lcd_is_swap_pending(void)
   return (uint32_t) ((hltdc.Instance->SRCR) & (LTDC_SRCR_VBR | LTDC_SRCR_IMR));
 }
 
-uint32_t lcd_sleep_while_swap_pending(void)
+bool lcd_sleep_while_swap_pending(void)
 {
-  uint32_t pending = lcd_is_swap_pending();
+  uint32_t pending = false;
 
-  if (pending)
+  while (lcd_is_swap_pending())
   {
-    while (lcd_is_swap_pending())
-    {
-      __WFI();
-    }
+    pending = true;
+    __WFI();
   }
 
   return pending;

--- a/Core/Src/porting/a7800/main_a7800.c
+++ b/Core/Src/porting/a7800/main_a7800.c
@@ -323,7 +323,6 @@ int app_main_a7800(uint8_t load_state, uint8_t start_paused, uint8_t save_slot)
         prosystem_ExecuteFrame(keyboard_data);
 
         if (drawFrame) {
-            common_sleep_while_lcd_swap_pending();
             blit();
             lcd_swap();
         }

--- a/Core/Src/porting/amstrad/main_amstrad.c
+++ b/Core/Src/porting/amstrad/main_amstrad.c
@@ -1158,7 +1158,6 @@ void app_main_amstrad(uint8_t load_state, uint8_t start_paused, uint8_t save_slo
 
         caprice_retro_loop();
         if (drawFrame) {
-            common_sleep_while_lcd_swap_pending();
             _blit();
             lcd_swap();
         }

--- a/Core/Src/porting/common.c
+++ b/Core/Src/porting/common.c
@@ -180,7 +180,7 @@ void common_emu_input_loop(odroid_gamepad_state_t *joystick, odroid_dialog_choic
 #if ENABLE_SCREENSHOT
                 printf("Capturing screenshot...\n");
                 odroid_audio_mute(true);
-                common_sleep_while_lcd_swap_pending();
+                lcd_sleep_while_swap_pending();
                 store_save((uint8_t *) framebuffer_capture, lcd_get_inactive_buffer(), sizeof(framebuffer_capture));
                 set_ingame_overlay(INGAME_OVERLAY_SC);
                 odroid_audio_mute(false);
@@ -311,7 +311,7 @@ void common_emu_input_loop(odroid_gamepad_state_t *joystick, odroid_dialog_choic
 
     if (clear_frames) {
         clear_frames--;
-        common_sleep_while_lcd_swap_pending();
+        lcd_sleep_while_swap_pending();
 
         // Clear the active screen buffer, caller must repaint it 
         memset(lcd_get_active_buffer(), 0, sizeof(framebuffer1));
@@ -628,14 +628,4 @@ void common_ingame_overlay(void) {
 static void set_ingame_overlay(ingame_overlay_t type){
     common_emu_state.overlay = type;
     common_emu_state.last_overlay_time = get_elapsed_time();
-}
-
-bool common_sleep_while_lcd_swap_pending() {
-    bool pending = false;
-    while (lcd_is_swap_pending()) {
-        pending = true;
-        cpumon_sleep();
-    }
-
-    return pending;
 }

--- a/Core/Src/porting/gb/main_gb.c
+++ b/Core/Src/porting/gb/main_gb.c
@@ -363,9 +363,6 @@ static void blit(void)
 
 static void blit_and_swap(void)
 {
-    // Temporary disabled as it causes sound jitter/issues (Verified in Super Mario Land 2.0 rom hack)
-    // common_sleep_while_lcd_swap_pending();
-
     blit();
     lcd_swap();
 }

--- a/Core/Src/porting/gwenesis/main_gwenesis.c
+++ b/Core/Src/porting/gwenesis/main_gwenesis.c
@@ -868,7 +868,7 @@ int app_main_gwenesis(uint8_t load_state, uint8_t start_paused, uint8_t save_slo
         } else {
           lcd_swap();
           drawFrame = 1;
-          common_sleep_while_lcd_swap_pending();
+          lcd_sleep_while_swap_pending();
         }
 
         /* AUDIO SYNC mode */

--- a/Core/Src/porting/msx/main_msx.c
+++ b/Core/Src/porting/msx/main_msx.c
@@ -1815,7 +1815,6 @@ void app_main_msx(uint8_t load_state, uint8_t start_paused, uint8_t save_slot)
         boardInfo.run(boardInfo.cpuRef);
 
         if (drawFrame) {
-            common_sleep_while_lcd_swap_pending();
             _blit();
             lcd_swap();
         }

--- a/Core/Src/porting/nes/main_nes.c
+++ b/Core/Src/porting/nes/main_nes.c
@@ -397,7 +397,6 @@ void osd_blitscreen(bitmap_t *bmp)
         lastFPSTime = currentTime;
     }
 
-    common_sleep_while_lcd_swap_pending();
     PROFILING_INIT(t_blit);
     PROFILING_START(t_blit);
 

--- a/Core/Src/porting/nes_fceu/main_nes_fceu.c
+++ b/Core/Src/porting/nes_fceu/main_nes_fceu.c
@@ -1148,7 +1148,6 @@ int app_main_nes_fceu(uint8_t load_state, uint8_t start_paused, uint8_t save_slo
         FCEUI_Emulate(&gfx, &sound, &ssize, !drawFrame);
         if (drawFrame)
         {
-            common_sleep_while_lcd_swap_pending();
             _blit();
             lcd_swap();
         }

--- a/Core/Src/porting/pce/main_pce.c
+++ b/Core/Src/porting/pce/main_pce.c
@@ -528,7 +528,6 @@ void blit() {
 }
 
 void pce_osd_gfx_blit() {
-    common_sleep_while_lcd_swap_pending();
 #ifdef PCE_SHOW_DEBUG
     uint32_t currentTime = HAL_GetTick();
     uint32_t delta = currentTime - lastFPSTime;

--- a/Core/Src/porting/smsplusgx/main_smsplusgx.c
+++ b/Core/Src/porting/smsplusgx/main_smsplusgx.c
@@ -394,7 +394,6 @@ static void sms_draw_frame()
                           ((0b0000000000011111 & p));
   }
 
-  common_sleep_while_lcd_swap_pending();
   blit();
   lcd_swap();
 }

--- a/Core/Src/porting/wsv/main_wsv.c
+++ b/Core/Src/porting/wsv/main_wsv.c
@@ -515,7 +515,6 @@ int app_main_wsv(uint8_t load_state, uint8_t start_paused, uint8_t save_slot)
 
         supervision_exec((uint16 *)wsv_framebuffer);
         if (drawFrame) {
-            common_sleep_while_lcd_swap_pending();
             blit();
             lcd_swap();
         }


### PR DESCRIPTION
LCD synchronization has been removed from all emulators as it was causing sound jitter.

The underlying reason is that the LCD with a 60 Hz refresh rate is a tad slower than the sound DMA buffer.
Sound is running about 60.05 Hz and LCD about 59.69 Hz.

Please note:
This "fix" is a regression back to an unsynchronized LCD double buffer system where a single frame is dropped every 2.7 sec when the swap and LCD reload occurs within a narrow window. Buffer tearing also exists every 2.7 for about 35 frames where the last 30 lines are taken from the active buffer rather than the inactive.

A new LCD syncing system without "wait for swap" need to be implemented to fix this across all emulators in general.

Please test this with a game in each emulator