### PR TITLE
Missing 50 60 Hz LCD fix for NES, Supervision and Amstrad

### DIFF
--- a/Core/Src/porting/amstrad/main_amstrad.c
+++ b/Core/Src/porting/amstrad/main_amstrad.c
@@ -1080,6 +1080,7 @@ void app_main_amstrad(uint8_t load_state, uint8_t start_paused, uint8_t save_slo
         common_emu_state.pause_after_frames = 0;
     }
     common_emu_state.frame_time_10us = (uint16_t)(100000 / AMSTRAD_FPS + 0.5f);
+    lcd_set_refresh_rate(AMSTRAD_FPS);
 
     memset(framebuffer1, 0, sizeof(framebuffer1));
     memset(framebuffer2, 0, sizeof(framebuffer2));

--- a/Core/Src/porting/common.c
+++ b/Core/Src/porting/common.c
@@ -24,11 +24,9 @@ static void set_ingame_overlay(ingame_overlay_t type);
 
 cpumon_stats_t cpumon_stats = {0};
 
-uint32_t audioBuffer[AUDIO_BUFFER_LENGTH];
 uint32_t audio_mute;
 
 
-int16_t pendingSamples = 0;
 int16_t audiobuffer_dma[AUDIO_BUFFER_LENGTH * 2] __attribute__((section (".audio")));
 
 dma_transfer_state_t dma_state;

--- a/Core/Src/porting/nes/main_nes.c
+++ b/Core/Src/porting/nes/main_nes.c
@@ -551,11 +551,13 @@ int app_main_nes(uint8_t load_state, uint8_t start_paused, uint8_t save_slot)
     memset(audiobuffer_dma, 0, sizeof(audiobuffer_dma));
 
     if (ACTIVE_FILE->region == REGION_PAL) {
+        lcd_set_refresh_rate(50);
         nes_region = NES_PAL;
         common_emu_state.frame_time_10us = (uint16_t)(100000 / 50 + 0.5f);
         samplesPerFrame = (AUDIO_SAMPLE_RATE) / 50;
         HAL_SAI_Transmit_DMA(&hsai_BlockA1, (uint8_t *) audiobuffer_dma,  (2 * AUDIO_SAMPLE_RATE) / 50);
     } else {
+        lcd_set_refresh_rate(60);
         nes_region = NES_NTSC;
         common_emu_state.frame_time_10us = (uint16_t)(100000 / 60 + 0.5f);
         //printf("frame_time_10us: %d\n", common_emu_state.frame_time_10us);

--- a/Core/Src/porting/nes_fceu/main_nes_fceu.c
+++ b/Core/Src/porting/nes_fceu/main_nes_fceu.c
@@ -1073,9 +1073,11 @@ int app_main_nes_fceu(uint8_t load_state, uint8_t start_paused, uint8_t save_slo
 
     HAL_SAI_DMAStop(&hsai_BlockA1);
     if (FSettings.PAL) {
+        lcd_set_refresh_rate(50);
         common_emu_state.frame_time_10us = (uint16_t)(100000 / 50 + 0.5f);
         samplesPerFrame = sndsamplerate / 50;
     } else {
+        lcd_set_refresh_rate(60);
         common_emu_state.frame_time_10us = (uint16_t)(100000 / 60 + 0.5f);
         samplesPerFrame = sndsamplerate / 60;
     }

--- a/Core/Src/porting/wsv/main_wsv.c
+++ b/Core/Src/porting/wsv/main_wsv.c
@@ -473,6 +473,7 @@ int app_main_wsv(uint8_t load_state, uint8_t start_paused, uint8_t save_slot)
         common_emu_state.pause_after_frames = 0;
     }
     common_emu_state.frame_time_10us = (uint16_t)(100000 / WSV_FPS + 0.5f);
+    lcd_set_refresh_rate(50);
 
     video_frame.buffer = wsv_framebuffer;
     memset(framebuffer1, 0, sizeof(framebuffer1));


### PR DESCRIPTION
This fix will set the correct LCD refresh rate for the below emulators to fix the 1 out of ~6 frame drop/jitter/tearing.
This was found while working on the UNSYNC_LCD_AGAIN branch.

Below pictures show when each half of the sound buffer is played vs "swap requested" and the actual LCD reload.
A low indicates "buffer 0" and a high indicates "buffer 1"

The missing transitions in "LCD Reload" is the smoking gun so to say.

NES
Before https://pasteboard.co/5MxsW8K2cHYE.png
After https://pasteboard.co/lMZiy7xCXZ42.png

Supervision
Before https://pasteboard.co/d4DMLl3u1Dk5.png
After https://pasteboard.co/xrEDFnlwm1dM.png

Amstrad
Before https://pasteboard.co/TkEfc9JAmPfq.png
After https://pasteboard.co/hjbgfU6Us41Y.png