### PR TITLE
Zelda3: add support for alternate languages

### DIFF
--- a/Makefile.common
+++ b/Makefile.common
@@ -759,12 +759,19 @@ ZELDA3_FEATURES := $(shell echo "$$(( $(ZELDA3_FEATURES) | $(ZELDA3_FEATURE_CANC
 ZELDA3_FEATURES := $(shell echo "$$(( $(ZELDA3_FEATURES) | $(ZELDA3_FEATURE_GAME_CHANGING_BUG_FIXES) << 14 ))")
 ZELDA3_FEATURES := $(shell echo "$$(( $(ZELDA3_FEATURES) | $(ZELDA3_FEATURE_SWITCH_LR_LIMIT) << 15 ))")
 
+# Support multiple languages
+ZELDA3_LOCALIZED_ROM=$(wildcard roms/zelda3/zelda3_??.sfc)
+ifneq ("$(ZELDA3_LOCALIZED_ROM)","")
+ZELDA3_DIALOGUES_LANGUAGE="$(patsubst roms/zelda3/zelda3_%.sfc,%,$(ZELDA3_LOCALIZED_ROM))"
+else
+ZELDA3_DIALOGUES_LANGUAGE=us
+endif
 
 # C defines for zelda3
 C_DEFS_ZELDA3 =  \
 -DHEADLESS \
 -DLIMIT_30FPS=$(ZELDA3_LIMIT_30FPS) \
--DDIALOGUES_LANGUAGE=us \
+-DDIALOGUES_LANGUAGE=$(ZELDA3_DIALOGUES_LANGUAGE) \
 -DFEATURES=$(ZELDA3_FEATURES) \
 -DFASTER_UI=$(ZELDA3_FASTER_UI) \
 -DBATTERY_INDICATOR=$(ZELDA3_BATTERY_INDICATOR) \
@@ -785,9 +792,17 @@ $(eval $(foreach obj,$(ZELDA3_C_SOURCES),$(call zelda3_obj_prereq_gen,$(obj))))
 Core/Src/porting/zelda3/zelda_assets.c: scripts/zelda3/update_assets.py zelda3/tables/zelda3_assets.dat | $(BUILD_DIR)
 	$(PYTHON3) ./scripts/zelda3/update_assets.py
 
+ifneq ("$(ZELDA3_LOCALIZED_ROM)","")
+zelda3/tables/zelda3_assets.dat: roms/zelda3/zelda3.sfc $(ZELDA3_LOCALIZED_ROM) | $(BUILD_DIR)
+	$(ECHO) "Extracting dialogues from localized ROM: $<"
+	cd zelda3/tables; $(PYTHON3) restool.py --extract-dialogue -r ../../$(ZELDA3_LOCALIZED_ROM)
+	$(ECHO) "Extracting game resources"
+	cd zelda3/tables; $(PYTHON3) restool.py --extract-from-rom --languages=$(ZELDA3_DIALOGUES_LANGUAGE) -r ../../roms/zelda3/zelda3.sfc
+else
 zelda3/tables/zelda3_assets.dat: roms/zelda3/zelda3.sfc | $(BUILD_DIR)
-	cp $< zelda3/tables/zelda3.sfc
-	$(MAKE) -C zelda3 tables/zelda3_assets.dat
+	$(ECHO) "Extracting game resources"
+	cd zelda3/tables; $(PYTHON3) restool.py --extract-from-rom -r ../../$<
+endif
 
 
 # SMW configuration

--- a/Makefile.common
+++ b/Makefile.common
@@ -760,7 +760,7 @@ ZELDA3_FEATURES := $(shell echo "$$(( $(ZELDA3_FEATURES) | $(ZELDA3_FEATURE_GAME
 ZELDA3_FEATURES := $(shell echo "$$(( $(ZELDA3_FEATURES) | $(ZELDA3_FEATURE_SWITCH_LR_LIMIT) << 15 ))")
 
 # Support multiple languages
-ZELDA3_LOCALIZED_ROM=$(wildcard roms/zelda3/zelda3_??.sfc)
+ZELDA3_LOCALIZED_ROM=$(wildcard roms/zelda3/zelda3_*.sfc)
 ifneq ("$(ZELDA3_LOCALIZED_ROM)","")
 ZELDA3_DIALOGUES_LANGUAGE="$(patsubst roms/zelda3/zelda3_%.sfc,%,$(ZELDA3_LOCALIZED_ROM))"
 else

--- a/README.md
+++ b/README.md
@@ -462,6 +462,20 @@ Some features can be configured with flags:
 | `FEATURE_GAME_CHANGING_BUG_FIXES` | Enable some more advanced zelda bugfixes that change game behavior. |
 | `FEATURE_SWITCH_LR_LIMIT` | Enable this to limit the ItemSwitchLR item cycling to the first 4 items. |
 
+#### Alternate languages
+
+By default, dialogues extracted from the US ROM are in english. You can replace dialogues with another language by adding a localized ROM file. Supported alternate languages are:
+
+| Language | Origin | Naming | SHA1 hash |
+| -------- | ------ | ------ | --------- |
+| German   | Original | zelda3_de.sfc | 2E62494967FB0AFDF5DA1635607F9641DF7C6559 |
+| French   | Original | zelda3_fr.sfc | 229364A1B92A05167CD38609B1AA98F7041987CC |
+| Spanish  | Romhack | zelda3_es.sfc | 461FCBD700D1332009C0E85A7A136E2A8E4B111E |
+| Polish   | Romhack | zelda3_pl.sfc | 3C4D605EEFDA1D76F101965138F238476655B11D |
+| Portuguese | Romhack | zelda3_pt.sfc | D0D09ED41F9C373FE6AFDCCAFBF0DA8C88D3D90D |
+| Dutch    | Romhack | zelda3_nl.sfc | FA8ADFDBA2697C9A54D583A1284A22AC764C7637 |
+| Swedish  | Romhack | zelda3_sv.sfc | 43CD3438469B2C3FE879EA2F410B3EF3CB3F1CA4 |
+
 ### Super Mario World
 
 To enable this port, copy the SNES ROM (US version) to `roms/smw/smw.sfc`.

--- a/README.md
+++ b/README.md
@@ -470,6 +470,8 @@ By default, dialogues extracted from the US ROM are in english. You can replace 
 | -------- | ------ | ------ | --------- |
 | German   | Original | zelda3_de.sfc | 2E62494967FB0AFDF5DA1635607F9641DF7C6559 |
 | French   | Original | zelda3_fr.sfc | 229364A1B92A05167CD38609B1AA98F7041987CC |
+| French (Canada) | Original | zelda3_fr-c.sfc | C1C6C7F76FFF936C534FF11F87A54162FC0AA100 |
+| English (Europe) | Original | zelda3_en.sfc | 7C073A222569B9B8E8CA5FCB5DFEC3B5E31DA895 |
 | Spanish  | Romhack | zelda3_es.sfc | 461FCBD700D1332009C0E85A7A136E2A8E4B111E |
 | Polish   | Romhack | zelda3_pl.sfc | 3C4D605EEFDA1D76F101965138F238476655B11D |
 | Portuguese | Romhack | zelda3_pt.sfc | D0D09ED41F9C373FE6AFDCCAFBF0DA8C88D3D90D |

--- a/parse_roms.py
+++ b/parse_roms.py
@@ -1176,6 +1176,8 @@ class ROMParser:
             'zelda3': {'embed': '0'},
             'zelda3_de': {'publish': '0'},
             'zelda3_fr': {'publish': '0'},
+            'zelda3_fr-c': {'publish': '0'},
+            'zelda3_en': {'publish': '0'},
             'zelda3_es': {'publish': '0'},
             'zelda3_pl': {'publish': '0'},
             'zelda3_pt': {'publish': '0'},

--- a/parse_roms.py
+++ b/parse_roms.py
@@ -1172,7 +1172,16 @@ class ROMParser:
         romdef.setdefault('wsv', {})
         romdef.setdefault('a7800', {})
         romdef.setdefault('amstrad', {})
-        romdef.setdefault('zelda3', {'zelda3': {'embed': '0'}})
+        romdef.setdefault('zelda3', {
+            'zelda3': {'embed': '0'},
+            'zelda3_de': {'publish': '0'},
+            'zelda3_fr': {'publish': '0'},
+            'zelda3_es': {'publish': '0'},
+            'zelda3_pl': {'publish': '0'},
+            'zelda3_pt': {'publish': '0'},
+            'zelda3_nl': {'publish': '0'},
+            'zelda3_sv': {'publish': '0'},
+        })
         romdef.setdefault('smw', {'smw': {'embed': '0'}})
 
         system_save_size, save_size, rom_size, img_size, current_id, larger_rom_size = self.generate_system(

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,4 @@
+-r zelda3/requirements.txt
 lz4
 pillow
 tqdm


### PR DESCRIPTION
This adds a feature to extract dialogues from a second rom file (among supported original languages and romhack translations).