### PR TITLE
Add reset support in smw and zelda3

### DIFF
--- a/Core/Src/porting/smw/main_smw.c
+++ b/Core/Src/porting/smw/main_smw.c
@@ -278,6 +278,15 @@ static void smw_sound_submit() {
   }
 }
 
+static bool reset_cb(odroid_dialog_choice_t *option, odroid_dialog_event_t event, uint32_t repeat)
+{
+  if (event == ODROID_DIALOG_ENTER) {
+    printf("Resetting\n");
+    RtlReset(1);
+  }
+  return event == ODROID_DIALOG_ENTER;
+}
+
 /* Main */
 int app_main_smw(uint8_t load_state, uint8_t start_paused, uint8_t save_slot)
 {
@@ -338,6 +347,7 @@ int app_main_smw(uint8_t load_state, uint8_t start_paused, uint8_t save_slot)
 
 
     odroid_dialog_choice_t options[] = {
+            {300, curr_lang->s_Reset, NULL, 1, &reset_cb},
             ODROID_DIALOG_CHOICE_LAST
     };
     void _repaint()

--- a/Core/Src/porting/zelda3/main_zelda3.c
+++ b/Core/Src/porting/zelda3/main_zelda3.c
@@ -300,6 +300,15 @@ static void zelda3_sound_submit() {
   }
 }
 
+static bool reset_cb(odroid_dialog_choice_t *option, odroid_dialog_event_t event, uint32_t repeat)
+{
+  if (event == ODROID_DIALOG_ENTER) {
+    printf("Resetting\n");
+    ZeldaReset(true);
+  }
+  return event == ODROID_DIALOG_ENTER;
+}
+
 /* Main */
 int app_main_zelda3(uint8_t load_state, uint8_t start_paused, uint8_t save_slot)
 {
@@ -370,6 +379,7 @@ int app_main_zelda3(uint8_t load_state, uint8_t start_paused, uint8_t save_slot)
 
 
     odroid_dialog_choice_t options[] = {
+            {300, curr_lang->s_Reset, NULL, 1, &reset_cb},
             ODROID_DIALOG_CHOICE_LAST
     };
     void _repaint()

--- a/smw_redefines
+++ b/smw_redefines
@@ -83,3 +83,8 @@ last_dma_state smw__last_dma_state
 renderedFrameCtr smw__renderedFrameCtr
 cpu_reset smw__cpu_reset
 Die smw__Die
+snes_reset smw__snes_reset
+cart_reset smw__cart_reset
+apu_reset smw__apu_reset
+RtlApuLock smw__RtlApuLock
+RtlApuUnlock smw__RtlApuUnlock

--- a/zelda3_redefines
+++ b/zelda3_redefines
@@ -83,3 +83,8 @@ last_dma_state zelda3__last_dma_state
 renderedFrameCtr zelda3__renderedFrameCtr
 cpu_reset zelda3__cpu_reset
 Die zelda3__Die
+snes_reset zelda3__snes_reset
+cart_reset zelda3__cart_reset
+apu_reset zelda3__apu_reset
+RtlApuLock zelda3__RtlApuLock
+RtlApuUnlock zelda3__RtlApuUnlock


### PR DESCRIPTION
Adds a menu option to reset the games. Useful with SRAM saves and to avoid getting stuck when the game requires reset (like SMW when you've beaten Bowser's Castle apparently).