### PR TITLE
Moved submodule refs back after PR merges

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,9 +1,9 @@
 [submodule "retro-go-stm32"]
 	path = retro-go-stm32
-	url = git@github.com:BenjaminSoelberg/retro-go-stm32.git
+	url = https://github.com/sylverb/retro-go-stm32.git
 [submodule "LCD-Game-Emulator"]
 	path = LCD-Game-Emulator
-	url = git@github.com:BenjaminSoelberg/LCD-Game-Emulator.git
+	url = https://github.com/sylverb/LCD-Game-Emulator.git
 [submodule "blueMSX-go"]
 	path = blueMSX-go
 	url = https://github.com/sylverb/blueMSX-go.git
@@ -12,7 +12,7 @@
 	url = https://github.com/sylverb/potator.git
 [submodule "gwenesis"]
 	path = gwenesis
-	url = https://github.com/sylverb/gwenesis
+	url = https://github.com/sylverb/gwenesis.git
 [submodule "prosystem-go"]
 	path = prosystem-go
 	url = https://github.com/sylverb/prosystem-go.git
@@ -30,4 +30,4 @@
 	url = https://github.com/marian-m12l/smw.git
 [submodule "tamalib"]
 	path = tamalib
-	url = git@github.com:BenjaminSoelberg/tamalib.git
+	url = https://github.com/BenjaminSoelberg/tamalib.git


### PR DESCRIPTION
This PR moves submodule references back to sylvers repos after a successfull merge