### PR TITLE
Check extflash params alignment

### DIFF
--- a/Makefile.common
+++ b/Makefile.common
@@ -19,6 +19,10 @@ LARGE_FLASH ?= 0
 # setting EXTFLASH_OFFSET. Useful if the first 1MB are to be preserved.
 EXTFLASH_OFFSET ?= 0
 
+ifneq ($(shell echo "$$(( $(EXTFLASH_OFFSET) % 4096 ))"), 0)
+$(error Invalid EXTFLASH_OFFSET, should be aligned to a 4KB sector)
+endif
+
 # Configure Game & Watch target device mario|zelda
 ifneq ($(findstring flash,$(MAKECMDGOALS)),flash)
 	GNW_TARGET ?= mario
@@ -107,6 +111,10 @@ EXTFLASH_SIZE_MB ?= 1
 BIG_BANK ?= 1
 
 EXTFLASH_SIZE ?= $(shell echo "$$(( $(EXTFLASH_SIZE_MB) * 1024 * 1024 ))")
+
+ifneq ($(shell echo "$$(( $(EXTFLASH_SIZE) % 4096 ))"), 0)
+$(error Invalid EXTFLASH_SIZE, should be aligned to a 4KB sector)
+endif
 
 EXTFLASH_FORCE_SPI ?= 0
 


### PR DESCRIPTION
This adds a couple of checks on extflash parameters to ensure alignment.

This was prompted by issues when following game-and-watch-patch instructions for stock zelda consoles, where the provided `EXTFLASH_SIZE` is not 4K-aligned. Since retro-go's linker script calculates `EXTFLASH_LENGTH` (and therefore the start address of subsequent regions: config, save, screenshot) by substracting from the end of allocated extflash, any misalignment in `EXTFLASH_OFFSET` or `EXTFLASH_SIZE` parameters will be carried to the start address of regions that are sized to exactly fit their expected content, yet ensure 4K alignment of their data, which would result in overflows in those regions (there's no room for fill/padding).