### PR TITLE
Usful modifications for at least Windows environment

### DIFF
--- a/Makefile.common
+++ b/Makefile.common
@@ -110,7 +110,15 @@ INTFLASH_BANK = 1
 endif
 endif
 
-GNWMANAGER = gnwmanager
+FORCE_PYOCD ?= 0
+GNWMANAGER_DEBUG ?= 0
+GNWMANAGER_PATH ?= gnwmanager
+GNWMANAGERVERBOSITY := $(if $(filter 1,$(GNWMANAGER_DEBUG)),--verbosity debug,)
+ifeq ($(FORCE_PYOCD),1)
+GNWMANAGER = $(GNWMANAGER_PATH) $(GNWMANAGERVERBOSITY) -b pyocd
+else
+GNWMANAGER = $(GNWMANAGER_PATH) $(GNWMANAGERVERBOSITY)
+endif
 
 # Configure external flash size in MB (Megabytes)
 EXTFLASH_SIZE_MB ?= 1


### PR DESCRIPTION
Add the possibility to force Pyocd for GNWManager, to define GNWManager path and to enable debug verbosity for GNWManager.